### PR TITLE
Optimize BITOP operations with AVX2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
         apt-get update && apt-get install -y build-essential
         echo $(gcc --version)
         make REDIS_CFLAGS='-Werror'
+        nm src/bitops.o
+        nm src/hyperloglog.o
+        nm -u src/redis-server
 
   build-macos-latest:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
     - name: make
       run: |
         apt-get update && apt-get install -y build-essential
-        make REDIS_CFLAGS='-Werror'
+        apt-get install -y gcc-10 g++-10
+        make CC=gcc-10 REDIS_CFLAGS='-Werror'
 
   build-macos-latest:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
     - name: make
       run: |
         apt-get update && apt-get install -y build-essential
+        echo $(gcc --version)
         make REDIS_CFLAGS='-Werror'
 
   build-macos-latest:
@@ -80,6 +81,7 @@ jobs:
     - name: make
       run: |
         dnf -y install which gcc gcc-c++ make
+        echo $(gcc --version)
         make REDIS_CFLAGS='-Werror'
 
   build-old-chain-jemalloc:
@@ -99,5 +101,4 @@ jobs:
         apt-get install -y make gcc-4.8 g++-4.8
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
-        echo $(gcc --version)
         make CC=gcc REDIS_CFLAGS='-Werror'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,5 @@ jobs:
         apt-get install -y make gcc-4.8 g++-4.8
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
+        echo $(gcc --version)
         make CC=gcc REDIS_CFLAGS='-Werror'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,7 @@ jobs:
     - name: make
       run: |
         apt-get update && apt-get install -y build-essential
-        apt-get install -y gcc-10 g++-10
-        make CC=gcc-10 REDIS_CFLAGS='-Werror'
+        make REDIS_CFLAGS='-Werror'
 
   build-macos-latest:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,7 @@ jobs:
     - name: make
       run: |
         apt-get update && apt-get install -y build-essential
-        echo $(gcc --version)
         make REDIS_CFLAGS='-Werror'
-        nm src/bitops.o
-        nm src/hyperloglog.o
-        nm -u src/redis-server
 
   build-macos-latest:
     runs-on: macos-latest
@@ -84,7 +80,6 @@ jobs:
     - name: make
       run: |
         dnf -y install which gcc gcc-c++ make
-        echo $(gcc --version)
         make REDIS_CFLAGS='-Werror'
 
   build-old-chain-jemalloc:

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -664,7 +664,7 @@ ATTRIBUTE_TARGET_AVX2
 unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res, 
                               unsigned long op, unsigned long numkeys,
                               unsigned long minlen) {
-    int i;
+    unsigned long i;
     int processed = 0;
 
     // TODO: this is debug code, remove.

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -666,7 +666,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
     const unsigned long step = sizeof(__m256i);
 
     unsigned long i;
-    int processed = 0;
+    unsigned int processed = 0;
     unsigned char *res_start = res;
     unsigned char *fst_key = keys[0];
     // TODO: this is debug code, remove.
@@ -701,7 +701,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
                 #if defined(AVX2_USE_LOADU)
                 __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
                 #else
-                __m256i lkey = _mm256_lddqu_si256((__m256i*)keys[i]+processed);
+                __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
                 #endif
 
                 lres = _mm256_and_si256(lres, lkey);
@@ -726,7 +726,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
                 #if defined(AVX2_USE_LOADU)
                 __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
                 #else
-                __m256i lkey = _mm256_lddqu_si256((__m256i*)keys[i]+processed);
+                __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
                 #endif
 
                 lres = _mm256_or_si256(lres, lkey);
@@ -748,7 +748,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
                 #if defined(AVX2_USE_LOADU)
                 __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
                 #else
-                __m256i lkey = _mm256_lddqu_si256((__m256i*)keys[i]+processed);
+                __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
                 #endif
 
                 lres = _mm256_xor_si256(lres, lkey);

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -666,7 +666,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
     const unsigned long step = sizeof(__m256i);
 
     unsigned long i;
-    int processed = 0;
+    unsigned long processed = 0;
     unsigned char *res_start = res;
     unsigned char *fst_key = keys[0];
     // TODO: this is debug code, remove.

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -7,7 +7,24 @@
  * (RSALv2) or the Server Side Public License v1 (SSPLv1).
  */
 
+#include "config.h"
 #include "server.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/cdefs.h>
+
+#ifdef HAVE_AVX2
+/* Define __MM_MALLOC_H to prevent importing the memory aligned
+ * allocation functions, which we don't use. */
+#define __MM_MALLOC_H
+#include <immintrin.h>
+#endif
+
+#ifdef HAVE_AVX2
+#define BITOP_USE_AVX2 (__builtin_cpu_supports("avx2"))
+#else
+#define BITOP_USE_AVX2 0
+#endif
 
 /* -----------------------------------------------------------------------------
  * Helpers and low level bit functions.
@@ -637,7 +654,142 @@ void getbitCommand(client *c) {
     addReply(c, bitval ? shared.cone : shared.czero);
 }
 
+#ifdef HAVE_AVX2
+/* Compute the given bitop operation using AVX2 intrinsics.
+ * Return how many bytes were successfully processed, as AVX2 operates on
+ * 256-bit registers so if `minlen` is not a multiple of 32 some of the bytes
+ * will be skipped. They will be taken care for in the unoptimized loop in the
+ * main bitopCommand function. */
+ATTRIBUTE_TARGET_AVX2
+unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res, 
+                              unsigned long op, unsigned long numkeys,
+                              unsigned long minlen) {
+    int i;
+    int processed = 0;
+
+    // TODO: this is debug code, remove.
+    char *bitop_disable_avx_env = getenv("BITOP_DISABLE_AVX");
+    if (bitop_disable_avx_env && strncmp(bitop_disable_avx_env, "1", 1)) {
+        return 0;
+    }
+
+    if (!(BITOP_USE_AVX2)) {
+        return 0;
+    }
+
+    const unsigned long step = sizeof(__m256i);
+    if (minlen < step) {
+        return 0;
+    }
+
+    memcpy(res, keys[0], minlen);
+
+    __m256i max256 = _mm256_set1_epi64x(-1);
+
+    switch (op) {
+    case BITOP_AND:
+        while (minlen >= step) {
+            #if defined(AVX2_USE_LOADU)
+            __m256i lres = _mm256_loadu_si256((__m256i*)res);
+            #else
+             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            #endif
+            for (i = 1; i < numkeys; i++) {
+                #if defined(AVX2_USE_LOADU)
+                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
+                #else
+                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
+                #endif
+
+                lres = _mm256_and_si256(lres, lkey);
+                keys[i] += step;
+            }
+            _mm256_storeu_si256((__m256i*)res, lres);
+            res += step;
+            processed += step;
+            minlen -= step;
+        }
+        break;
+    case BITOP_OR:
+        while (minlen >= step) {
+            #if defined(AVX2_USE_LOADU)
+            __m256i lres = _mm256_loadu_si256((__m256i*)res);
+            #else
+             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            #endif
+            for (i = 1; i < numkeys; i++) {
+                #if defined(AVX2_USE_LOADU)
+                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
+                #else
+                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
+                #endif
+
+                lres = _mm256_or_si256(lres, lkey);
+                keys[i] += step;
+            }
+            _mm256_storeu_si256((__m256i*)res, lres);
+            res += step;
+            processed += step;
+            minlen -= step;
+        }
+        break;
+    case BITOP_XOR:
+        while (minlen >= step) {
+            #if defined(AVX2_USE_LOADU)
+            __m256i lres = _mm256_loadu_si256((__m256i*)res);
+            #else
+             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            #endif
+            for (i = 1; i < numkeys; i++) {
+                #if defined(AVX2_USE_LOADU)
+                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
+                #else
+                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
+                #endif
+
+                lres = _mm256_xor_si256(lres, lkey);
+                keys[i] += step;
+            }
+            _mm256_storeu_si256((__m256i*)res, lres);
+            res += step;
+            processed += step;
+            minlen -= step;
+        }
+        break;
+    case BITOP_NOT:
+        while (minlen >= step) {
+            #if defined(AVX2_USE_LOADU)
+            __m256i lres = _mm256_loadu_si256((__m256i*)res);
+            #else
+             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            #endif
+            lres = _mm256_xor_si256(lres, max256);
+            _mm256_storeu_si256((__m256i*)res, lres);
+            res += step;
+            processed += step;
+            minlen -= step;
+        }
+        break;
+    case BITOP_DIFF:
+        break;
+    case BITOP_DIFF1:
+        break;
+    case BITOP_ANDOR:
+        break;
+    case BITOP_ONE:
+        break;
+    default:
+        break;
+    }
+
+    return processed;
+}
+#endif // HAVE_AVX2
+
 /* BITOP op_name target_key src_key1 src_key2 src_key3 ... src_keyN */
+#ifdef HAVE_AVX2
+ATTRIBUTE_TARGET_AVX2
+#endif
 REDIS_NO_SANITIZE("alignment")
 void bitopCommand(client *c) {
     char *opname = c->argv[1]->ptr;
@@ -723,20 +875,26 @@ void bitopCommand(client *c) {
         unsigned char output, byte, disjunction, common_bits;
         unsigned long i;
 
-        /* Fast path: as far as we have data for all the input bitmaps we
+        j = 0;
+
+#if defined(HAVE_AVX2)
+        j = bitopCommandAVX(src, res, op, numkeys, minlen);
+#endif
+
+#if !defined(USE_ALIGNED_ACCESS)
+        /* We don't have AVX2 but we still have fast path:
+         * as far as we have data for all the input bitmaps we
          * can take a fast path that performs much better than the
          * vanilla algorithm. On ARM we skip the fast path since it will
          * result in GCC compiling the code using multiple-words load/store
          * operations that are not supported even in ARM >= v6. */
-        j = 0;
-        #ifndef USE_ALIGNED_ACCESS
         if (minlen >= sizeof(unsigned long)*4 && numkeys <= 16) {
             unsigned long *lp[16];
             unsigned long *lres = (unsigned long*) res;
             unsigned long *first_key = (unsigned long*)src[0];
             unsigned long lcommon_bits[4];
 
-            size_t step = sizeof(unsigned long)*4;
+            const size_t step = sizeof(unsigned long)*4;
             size_t processed = 0;
 
             memcpy(lp,src,sizeof(unsigned long*)*numkeys);
@@ -870,7 +1028,7 @@ void bitopCommand(client *c) {
                 }
             }
         }
-        #endif
+#endif // !defined(USE_ALIGNED_ACCESS)
 
         /* j is set to the next byte to process by the previous loop. */
         for (; j < maxlen; j++) {

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -663,12 +663,15 @@ ATTRIBUTE_TARGET_AVX2
 unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res, 
                               unsigned long op, unsigned long numkeys,
                               unsigned long minlen) {
+    const unsigned long step = sizeof(__m256i);
+
     unsigned long i;
     int processed = 0;
-
+    unsigned char *res_start = res;
+    unsigned char *fst_key = keys[0];
     // TODO: this is debug code, remove.
     char *bitop_disable_avx_env = getenv("BITOP_DISABLE_AVX");
-    if (bitop_disable_avx_env && strncmp(bitop_disable_avx_env, "1", 1)) {
+    if (bitop_disable_avx_env && !strncmp(bitop_disable_avx_env, "1", 1)) {
         return 0;
     }
 
@@ -676,12 +679,12 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         return 0;
     }
 
-    const unsigned long step = sizeof(__m256i);
-    if (minlen < step) {
         return 0;
     }
 
-    memcpy(res, keys[0], minlen);
+    if (op != BITOP_DIFF && op != BITOP_DIFF1 && op != BITOP_ANDOR) {
+        memcpy(res, fst_key, minlen);
+    }
 
     __m256i max256 = _mm256_set1_epi64x(-1);
 
@@ -697,11 +700,10 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
                 #if defined(AVX2_USE_LOADU)
                 __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
                 #else
-                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
+                __m256i lkey = _mm256_lddqu_si256((__m256i*)keys[i]+processed);
                 #endif
 
                 lres = _mm256_and_si256(lres, lkey);
-                keys[i] += step;
             }
             _mm256_storeu_si256((__m256i*)res, lres);
             res += step;
@@ -709,6 +711,9 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
             minlen -= step;
         }
         break;
+    case BITOP_DIFF:
+    case BITOP_DIFF1:
+    case BITOP_ANDOR:
     case BITOP_OR:
         while (minlen >= step) {
             #if defined(AVX2_USE_LOADU)
@@ -720,11 +725,10 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
                 #if defined(AVX2_USE_LOADU)
                 __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
                 #else
-                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
+                __m256i lkey = _mm256_lddqu_si256((__m256i*)keys[i]+processed);
                 #endif
 
                 lres = _mm256_or_si256(lres, lkey);
-                keys[i] += step;
             }
             _mm256_storeu_si256((__m256i*)res, lres);
             res += step;
@@ -743,11 +747,10 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
                 #if defined(AVX2_USE_LOADU)
                 __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
                 #else
-                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
+                __m256i lkey = _mm256_lddqu_si256((__m256i*)keys[i]+processed);
                 #endif
 
                 lres = _mm256_xor_si256(lres, lkey);
-                keys[i] += step;
             }
             _mm256_storeu_si256((__m256i*)res, lres);
             res += step;
@@ -769,13 +772,58 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
             minlen -= step;
         }
         break;
+    case BITOP_ONE:
+        break;
+    default:
+        break;
+    }
+
+    res = res_start;
+    switch (op) {
     case BITOP_DIFF:
+        for (i = 0; i < processed; i += step) {
+            #if defined(AVX2_USE_LOADU)
+            __m256i lres = _mm256_loadu_si256((__m256i*)res);
+            #else
+            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            __m256i fkey = _mm256_lddqu_si256((__m256i*)fst_key);
+            #endif
+            lres = _mm256_andnot_si256(lres, fkey);
+            _mm256_storeu_si256((__m256i*)res, lres);
+
+            res += step;
+            fst_key += step;
+        }
         break;
     case BITOP_DIFF1:
+        for (i = 0; i < processed; i += step) {
+            #if defined(AVX2_USE_LOADU)
+            __m256i lres = _mm256_loadu_si256((__m256i*)res);
+            #else
+            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            __m256i fkey = _mm256_lddqu_si256((__m256i*)fst_key);
+            #endif
+            lres = _mm256_andnot_si256(fkey, lres);
+            _mm256_storeu_si256((__m256i*)res, lres);
+
+            res += step;
+            fst_key += step;
+        }
         break;
     case BITOP_ANDOR:
-        break;
-    case BITOP_ONE:
+        for (i = 0; i < processed; i += step) {
+            #if defined(AVX2_USE_LOADU)
+            __m256i lres = _mm256_loadu_si256((__m256i*)res);
+            #else
+            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            __m256i fkey = _mm256_lddqu_si256((__m256i*)fst_key);
+            #endif
+            lres = _mm256_and_si256(fkey, lres);
+            _mm256_storeu_si256((__m256i*)res, lres);
+
+            res += step;
+            fst_key += step;
+        }
         break;
     default:
         break;
@@ -875,6 +923,7 @@ void bitopCommand(client *c) {
 
 #if defined(HAVE_AVX2)
         j = bitopCommandAVX(src, res, op, numkeys, minlen);
+        minlen -= j;
 #endif
 
 #if !defined(USE_ALIGNED_ACCESS)

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -666,7 +666,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
     const unsigned long step = sizeof(__m256i);
 
     unsigned long i;
-    unsigned int processed = 0;
+    int processed = 0;
     unsigned char *res_start = res;
     unsigned char *fst_key = keys[0];
     // TODO: this is debug code, remove.
@@ -683,27 +683,21 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         return 0;
     }
 
+
     if (op != BITOP_DIFF && op != BITOP_DIFF1 && op != BITOP_ANDOR) {
-        memcpy(res, fst_key, minlen);
+        memcpy(res, keys[0], minlen);
     }
 
-    __m256i max256 = _mm256_set1_epi64x(-1);
+    const __m256i max256 = _mm256_set1_epi64x(-1);
+    const __m256i zero256 = _mm256_set1_epi64x(0);
 
     switch (op) {
     case BITOP_AND:
         while (minlen >= step) {
-            #if defined(AVX2_USE_LOADU)
-            __m256i lres = _mm256_loadu_si256((__m256i*)res);
-            #else
-             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
-            #endif
-            for (i = 1; i < numkeys; i++) {
-                #if defined(AVX2_USE_LOADU)
-                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
-                #else
-                __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
-                #endif
+            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
 
+            for (i = 1; i < numkeys; i++) {
+                __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
                 lres = _mm256_and_si256(lres, lkey);
             }
             _mm256_storeu_si256((__m256i*)res, lres);
@@ -717,18 +711,10 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
     case BITOP_ANDOR:
     case BITOP_OR:
         while (minlen >= step) {
-            #if defined(AVX2_USE_LOADU)
-            __m256i lres = _mm256_loadu_si256((__m256i*)res);
-            #else
-             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
-            #endif
-            for (i = 1; i < numkeys; i++) {
-                #if defined(AVX2_USE_LOADU)
-                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
-                #else
-                __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
-                #endif
+            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
 
+            for (i = 1; i < numkeys; i++) {
+                __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
                 lres = _mm256_or_si256(lres, lkey);
             }
             _mm256_storeu_si256((__m256i*)res, lres);
@@ -739,18 +725,10 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         break;
     case BITOP_XOR:
         while (minlen >= step) {
-            #if defined(AVX2_USE_LOADU)
-            __m256i lres = _mm256_loadu_si256((__m256i*)res);
-            #else
-             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
-            #endif
-            for (i = 1; i < numkeys; i++) {
-                #if defined(AVX2_USE_LOADU)
-                __m256i lkey = _mm256_loadu_si256((__m256i*)keys[i]);
-                #else
-                __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
-                #endif
+            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
 
+            for (i = 1; i < numkeys; i++) {
+                __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
                 lres = _mm256_xor_si256(lres, lkey);
             }
             _mm256_storeu_si256((__m256i*)res, lres);
@@ -761,11 +739,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         break;
     case BITOP_NOT:
         while (minlen >= step) {
-            #if defined(AVX2_USE_LOADU)
-            __m256i lres = _mm256_loadu_si256((__m256i*)res);
-            #else
              __m256i lres = _mm256_lddqu_si256((__m256i*)res);
-            #endif
             lres = _mm256_xor_si256(lres, max256);
             _mm256_storeu_si256((__m256i*)res, lres);
             res += step;
@@ -774,6 +748,23 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         }
         break;
     case BITOP_ONE:
+	while (minlen >= step) {
+            __m256i lres = _mm256_lddqu_si256((__m256i*)res);
+            __m256i common_bits = zero256;
+
+            for (i = 1; i < numkeys; i++) {
+                __m256i lkey = _mm256_lddqu_si256((__m256i*)(keys[i]+processed));
+                __m256i common = _mm256_and_si256(lres, lkey);
+                common_bits = _mm256_or_si256(common_bits, common);
+
+                lres = _mm256_xor_si256(lres, lkey);
+            }
+            lres = _mm256_andnot_si256(common_bits, lres);
+            _mm256_storeu_si256((__m256i*)res, lres);
+            res += step;
+            processed += step;
+            minlen -= step;
+        }
         break;
     default:
         break;
@@ -783,12 +774,9 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
     switch (op) {
     case BITOP_DIFF:
         for (i = 0; i < processed; i += step) {
-            #if defined(AVX2_USE_LOADU)
-            __m256i lres = _mm256_loadu_si256((__m256i*)res);
-            #else
             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
             __m256i fkey = _mm256_lddqu_si256((__m256i*)fst_key);
-            #endif
+
             lres = _mm256_andnot_si256(lres, fkey);
             _mm256_storeu_si256((__m256i*)res, lres);
 
@@ -798,12 +786,9 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         break;
     case BITOP_DIFF1:
         for (i = 0; i < processed; i += step) {
-            #if defined(AVX2_USE_LOADU)
-            __m256i lres = _mm256_loadu_si256((__m256i*)res);
-            #else
             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
             __m256i fkey = _mm256_lddqu_si256((__m256i*)fst_key);
-            #endif
+
             lres = _mm256_andnot_si256(fkey, lres);
             _mm256_storeu_si256((__m256i*)res, lres);
 
@@ -813,12 +798,9 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         break;
     case BITOP_ANDOR:
         for (i = 0; i < processed; i += step) {
-            #if defined(AVX2_USE_LOADU)
-            __m256i lres = _mm256_loadu_si256((__m256i*)res);
-            #else
             __m256i lres = _mm256_lddqu_si256((__m256i*)res);
             __m256i fkey = _mm256_lddqu_si256((__m256i*)fst_key);
-            #endif
+
             lres = _mm256_and_si256(fkey, lres);
             _mm256_storeu_si256((__m256i*)res, lres);
 
@@ -934,16 +916,15 @@ void bitopCommand(client *c) {
          * vanilla algorithm. On ARM we skip the fast path since it will
          * result in GCC compiling the code using multiple-words load/store
          * operations that are not supported even in ARM >= v6. */
-        if (minlen >= sizeof(unsigned long)*4 && numkeys <= 16) {
-            unsigned long *lp[16];
+        if (minlen >= sizeof(unsigned long)*4) {
+            unsigned long **lp = (unsigned long**)src;
             unsigned long *lres = (unsigned long*) res;
             unsigned long *first_key = (unsigned long*)src[0];
             unsigned long lcommon_bits[4];
 
             const size_t step = sizeof(unsigned long)*4;
             size_t processed = 0;
-
-            memcpy(lp,src,sizeof(unsigned long*)*numkeys);
+            size_t k = 0;
 
             if (op != BITOP_DIFF && op != BITOP_DIFF1 && op != BITOP_ANDOR)
                 memcpy(lres,src[0],minlen);
@@ -952,12 +933,12 @@ void bitopCommand(client *c) {
             if (op == BITOP_AND) {
                 while(minlen >= step) {
                     for (i = 1; i < numkeys; i++) {
-                        lres[0] &= lp[i][0];
-                        lres[1] &= lp[i][1];
-                        lres[2] &= lp[i][2];
-                        lres[3] &= lp[i][3];
-                        lp[i] += 4;
+                        lres[0] &= lp[i][k+0];
+                        lres[1] &= lp[i][k+1];
+                        lres[2] &= lp[i][k+2];
+                        lres[3] &= lp[i][k+3];
                     }
+                    k += 4;
                     lres += 4;
                     j += step;
                     minlen -= step;
@@ -965,12 +946,12 @@ void bitopCommand(client *c) {
             } else if (op == BITOP_OR) {
                 while(minlen >= step) {
                     for (i = 1; i < numkeys; i++) {
-                        lres[0] |= lp[i][0];
-                        lres[1] |= lp[i][1];
-                        lres[2] |= lp[i][2];
-                        lres[3] |= lp[i][3];
-                        lp[i]+=4;
+                        lres[0] |= lp[i][k+0];
+                        lres[1] |= lp[i][k+1];
+                        lres[2] |= lp[i][k+2];
+                        lres[3] |= lp[i][k+3];
                     }
+                    k += 4;
                     lres += 4;
                     j += step;
                     minlen -= step;
@@ -978,12 +959,12 @@ void bitopCommand(client *c) {
             } else if (op == BITOP_XOR) {
                 while(minlen >= step) {
                     for (i = 1; i < numkeys; i++) {
-                        lres[0] ^= lp[i][0];
-                        lres[1] ^= lp[i][1];
-                        lres[2] ^= lp[i][2];
-                        lres[3] ^= lp[i][3];
-                        lp[i]+=4;
+                        lres[0] ^= lp[i][k+0];
+                        lres[1] ^= lp[i][k+1];
+                        lres[2] ^= lp[i][k+2];
+                        lres[3] ^= lp[i][k+3];
                     }
+                    k += 4;
                     lres += 4;
                     j += step;
                     minlen -= step;
@@ -1001,12 +982,12 @@ void bitopCommand(client *c) {
             } else if (op == BITOP_DIFF || op == BITOP_DIFF1 || op == BITOP_ANDOR) {
                 while(minlen >= step) {
                     for (i = 1; i < numkeys; i++) {
-                        lres[0] |= lp[i][0];
-                        lres[1] |= lp[i][1];
-                        lres[2] |= lp[i][2];
-                        lres[3] |= lp[i][3];
-                        lp[i] += 4;
+                        lres[0] |= lp[i][k+0];
+                        lres[1] |= lp[i][k+1];
+                        lres[2] |= lp[i][k+2];
+                        lres[3] |= lp[i][k+3];
                     }
+                    k += 4;
                     lres += 4;
                     j += step;
                     minlen -= step;
@@ -1051,23 +1032,23 @@ void bitopCommand(client *c) {
                     memset(lcommon_bits, 0, sizeof(unsigned long)*4);
 
                     for (i = 1; i < numkeys; i++) {
-                        lcommon_bits[0] |= (lres[0] & lp[i][0]);
-                        lcommon_bits[1] |= (lres[1] & lp[i][1]);
-                        lcommon_bits[2] |= (lres[2] & lp[i][2]);
-                        lcommon_bits[3] |= (lres[3] & lp[i][3]);
+                        lcommon_bits[0] |= (lres[0] & lp[i][k+0]);
+                        lcommon_bits[1] |= (lres[1] & lp[i][k+1]);
+                        lcommon_bits[2] |= (lres[2] & lp[i][k+2]);
+                        lcommon_bits[3] |= (lres[3] & lp[i][k+3]);
 
-                        lres[0] ^= lp[i][0];
-                        lres[1] ^= lp[i][1];
-                        lres[2] ^= lp[i][2];
-                        lres[3] ^= lp[i][3];
-
-                        lres[0] &= ~lcommon_bits[0];
-                        lres[1] &= ~lcommon_bits[1];
-                        lres[2] &= ~lcommon_bits[2];
-                        lres[3] &= ~lcommon_bits[3];
-
-                        lp[i] += 4;
+                        lres[0] ^= lp[i][k+0];
+                        lres[1] ^= lp[i][k+1];
+                        lres[2] ^= lp[i][k+2];
+                        lres[3] ^= lp[i][k+3];
                     }
+
+                    lres[0] &= ~lcommon_bits[0];
+                    lres[1] &= ~lcommon_bits[1];
+                    lres[2] &= ~lcommon_bits[2];
+                    lres[3] &= ~lcommon_bits[3];
+
+                    k += 4;
                     lres += 4;
                     j += step;
                     minlen -= step;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -7,7 +7,6 @@
  * (RSALv2) or the Server Side Public License v1 (SSPLv1).
  */
 
-#include "config.h"
 #include "server.h"
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -675,14 +675,9 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         return 0;
     }
 
-    if (!(BITOP_USE_AVX2)) {
-        return 0;
-    }
-
     if (minlen < step) {
         return 0;
     }
-
 
     if (op != BITOP_DIFF && op != BITOP_DIFF1 && op != BITOP_ANDOR) {
         memcpy(res, keys[0], minlen);
@@ -905,8 +900,10 @@ void bitopCommand(client *c) {
         j = 0;
 
 #if defined(HAVE_AVX2)
-        j = bitopCommandAVX(src, res, op, numkeys, minlen);
-        minlen -= j;
+        if (BITOP_USE_AVX2) {
+            j = bitopCommandAVX(src, res, op, numkeys, minlen);
+            minlen -= j;
+        }
 #endif
 
 #if !defined(USE_ALIGNED_ACCESS)

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -679,6 +679,7 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
         return 0;
     }
 
+    if (minlen < step) {
         return 0;
     }
 

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -787,9 +787,6 @@ unsigned long bitopCommandAVX(unsigned char **keys, unsigned char *res,
 #endif // HAVE_AVX2
 
 /* BITOP op_name target_key src_key1 src_key2 src_key3 ... src_keyN */
-#ifdef HAVE_AVX2
-ATTRIBUTE_TARGET_AVX2
-#endif
 REDIS_NO_SANITIZE("alignment")
 void bitopCommand(client *c) {
     char *opname = c->argv[1]->ptr;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -8,9 +8,6 @@
  */
 
 #include "server.h"
-#include <stdint.h>
-#include <stdlib.h>
-#include <sys/cdefs.h>
 
 #ifdef HAVE_AVX2
 /* Define __MM_MALLOC_H to prevent importing the memory aligned


### PR DESCRIPTION
# **Description**

Added hand-written SIMD optimization (via AVX2 instruction set - 256bit register) for the BITOP operations including the new ops.

## **Benchmarks**

This commit actually includes two optimizations:
* In the old code the fast path was for some reason limited to 16 source keys, meaning any command containing more than that would needlessly be computed via the slow-path (byte by byte). The compiler actually generates SIMD instructions for the fast-path, albeit they are SSE (128-bit register). So one of the optimizations here was to remove that limitation. A small benchmark shows no performance change for the 16 keys case:
```
==================================================================================================
Type         Ops/sec     Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
===============================================and================================================
Key Size: 32B | Key Count: 16 | Kb/s Change: -0.74%
and-old      70369.98         2.84272         2.78300         5.53500        27.64700     27075.95
and-new      70387.83         2.84409         2.78300         5.50300        27.64700     26876.60
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 16 | Kb/s Change: +0.67%
and-old      64193.80         3.11139         2.91100         4.73500        26.11100     24887.64
and-new      65116.61         3.07074         2.87900         4.67100        25.59900     25054.63
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 16 | Kb/s Change: +0.28%
and-old      36774.40         5.43406         5.37500         8.25500        29.69500     14293.18
and-new      36971.43         5.40152         5.37500         7.93500        29.95100     14333.65
--------------------------------------------------------------------------------------------------

===============================================not================================================
Key Size: 32B | Key Count: 16 | Kb/s Change: -0.23%
not-old      71630.54         2.77681         2.55900         7.19900        29.69500     31198.46
not-new      71953.26         2.76820         2.52700         7.51900        29.43900     31128.22
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 16 | Kb/s Change: +0.99%
not-old      71203.79         2.81134         2.57500         7.42300        29.31100     31082.12
not-new      72396.41         2.77040         2.52700         7.35900        30.59100     31390.63
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 16 | Kb/s Change: +1.78%
not-old      71823.49         2.78497         2.55900         7.29500        29.43900     31352.64
not-new      73262.70         2.77885         2.54300         7.32700        30.59100     31909.34
--------------------------------------------------------------------------------------------------
```

* The next optimization was to have a faster-path - a function to compute the BITOP command via AVX2 instructions. This is guarded by a runtime check. Next follows a benchmark with different key sizes and key counts. The OR/XOR ops were skipped as they should have roughly the same performance as AND (having the same amount of instructions), same for DIFF1/ANDOR respectively for DIFF.
```
==================================================================================================
Type         Ops/sec     Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
===============================================and================================================
Key Size: 32B | Key Count: 16 | Kb/s Change: 0.49%
and-sse      70387.83         2.84409         2.78300         5.50300        27.64700     26876.60
and-avx      70193.22         2.83733         2.78300         5.59900        27.13500     27007.94
--------------------------------------------------------------------------------------------------
Key Size: 32B | Key Count: 35 | Kb/s Change: 0.12%
and-sse      58192.50         3.43708         3.19900         5.18300        26.75100     46088.01
and-avx      58260.16         3.42779         3.19900         5.18300        26.87900     46141.59
--------------------------------------------------------------------------------------------------
Key Size: 32B | Key Count: 101 | Kb/s Change: 0.53%
and-sse      36541.69         5.46911         5.27900         8.19100        30.46300     80291.81
and-avx      36671.93         5.44666         5.24700         8.19100        30.33500     80721.22
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 16 | Kb/s Change: 3.93%
and-sse      65116.61         3.07074         2.87900         4.67100        25.59900     25054.63
and-avx      67331.58         2.97168         2.79900         4.57500        25.72700     26038.38
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 35 | Kb/s Change: 7.47%
and-sse      50265.81         3.97693         3.69500         5.91900        27.39100     39859.21
and-avx      54218.84         3.68609         3.40700         5.50300        26.75100     42835.00
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 101 | Kb/s Change: 14.02%
and-sse      27595.85         7.22707         7.13500        15.42300        33.53500     60851.01
and-avx      31463.75         6.35734         6.20700        12.03100        31.61500     69380.02
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 16 | Kb/s Change: 34.55%
and-sse      36971.43         5.40152         5.37500         7.93500        29.95100     14333.65
and-avx      50124.50         3.99364         3.71100         5.88700        27.64700     19286.18
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 35 | Kb/s Change: 56.88%
and-sse      19467.69        10.25459        10.81500        23.16700        37.88700     15494.30
and-avx      30654.04         6.49009         6.52700        12.35100        31.48700     24307.69
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 101 | Kb/s Change: 51.80%
and-sse       6502.76        30.93543        33.02300        56.57500        71.16700     14313.69
and-avx       9849.15        20.28068        21.37500        39.93500        53.75900     21727.75
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 16 | Kb/s Change: 120.30%
and-sse       8752.83        22.82167        25.59900        44.03100        57.85500      3376.34
and-avx      19234.07        10.38190        11.07100        23.29500        38.39900      7438.18
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 35 | Kb/s Change: 83.92%
and-sse       3839.78        51.99465        58.36700        86.01500       104.44700      3048.58
and-avx       7062.08        28.37415        31.48700        50.68700        64.51100      5606.91
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 101 | Kb/s Change: 71.21%
and-sse       1135.79       176.07966       191.48700       234.49500       260.09500      2503.41
and-avx       1945.45       103.15990       113.15100       141.31100       154.62300      4286.08
--------------------------------------------------------------------------------------------------

===============================================not================================================
Key Size: 32B | Key Count: 16 | Kb/s Change: 1.84%
not-sse      71953.26         2.76820         2.52700         7.51900        29.43900     31128.22
not-avx      72787.47         2.75363         2.52700         7.13500        29.43900     31702.36
--------------------------------------------------------------------------------------------------
Key Size: 32B | Key Count: 35 | Kb/s Change: 0.50%
not-sse      63892.82         3.11004         2.92700         7.48700        29.95100     53847.17
not-avx      64214.52         3.08232         2.91100         7.26300        31.99900     54118.29
--------------------------------------------------------------------------------------------------
Key Size: 32B | Key Count: 101 | Kb/s Change: -0.69%
not-sse      48242.66         4.14489         4.12700         7.26300        31.99900    108451.76
not-avx      47825.03         4.27749         4.25500         7.45500        31.48700    107699.72
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 16 | Kb/s Change: 1.00%
not-sse      72396.41         2.77040         2.52700         7.35900        30.59100     31390.63
not-avx      72795.32         2.76288         2.54300         7.16700        30.59100     31705.77
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 35 | Kb/s Change: 5.49%
not-sse      61533.91         3.23348         2.99100         8.25500        34.30300     51799.05
not-avx      65138.74         3.07684         2.91100         7.16700        30.59100     54642.76
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 101 | Kb/s Change: -0.30%
not-sse      46746.26         4.30785         4.28700         7.67900        31.87100    105361.69
not-avx      46607.80         4.29269         4.28700         7.51900        32.63900    105049.61
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 16 | Kb/s Change: -3.35%
not-sse      73262.70         2.77885         2.54300         7.32700        30.59100     31909.34
not-avx      71291.32         2.79406         2.55900         7.39100        31.35900     30841.85
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 35 | Kb/s Change: 0.77%
not-sse      64523.57         3.09342         2.92700         7.35900        32.38300     54441.77
not-avx      65248.87         3.05533         2.87900         7.13500        30.59100     54862.57
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 101 | Kb/s Change: -2.49%
not-sse      47780.43         4.18042         4.15900         7.39100        33.02300    107459.30
not-avx      46491.41         4.29091         4.28700         7.61500        34.04700    104787.28
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 16 | Kb/s Change: 0.61%
not-sse      71403.56         2.79085         2.55900         7.35900        30.59100     30960.14
not-avx      71679.42         2.78756         2.54300         7.55100        31.10300     31149.75
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 35 | Kb/s Change: 0.65%
not-sse      64869.64         3.09264         2.91100         7.35900        29.43900     54607.06
not-avx      65292.84         3.04994         2.87900         7.26300        31.10300     54963.31
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 101 | Kb/s Change: -1.99%
not-sse      47481.38         4.28413         4.25500         7.45500        31.74300    106925.84
not-avx      46556.53         4.30004         4.28700         7.51900        34.30300    104797.65
--------------------------------------------------------------------------------------------------

===============================================diff===============================================
Key Size: 32B | Key Count: 16 | Kb/s Change: 0.69%
diff-sse      70548.19         2.83800         2.78300         5.37500        27.13500     27075.62
diff-avx      70496.24         2.83134         2.78300         5.59900        27.00700     27262.22
--------------------------------------------------------------------------------------------------
Key Size: 32B | Key Count: 35 | Kb/s Change: 1.27%
diff-sse      57720.34         3.46024         3.23100         5.24700        26.87900     45826.80
diff-avx      58455.00         3.42289         3.18300         5.18300        27.00700     46410.08
--------------------------------------------------------------------------------------------------
Key Size: 32B | Key Count: 101 | Kb/s Change: 3.80%
diff-sse      36353.32         5.49779         5.27900         8.44700        30.46300     79948.91
diff-avx      37669.12         5.31110         5.11900         7.93500        29.82300     82989.77
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 16 | Kb/s Change: 3.88%
diff-sse      64278.03         3.10428         2.89500         4.70300        25.98300     24857.52
diff-avx      66438.33         3.00776         2.83100         4.60700        26.11100     25822.71
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 35 | Kb/s Change: 7.38%
diff-sse      49238.36         4.05279         3.77500         5.98300        27.64700     39140.65
diff-avx      53068.52         3.76783         3.48700         5.63100        27.26300     42029.86
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 101 | Kb/s Change: 11.22%
diff-sse      27216.19         7.34354         7.26300        15.74300        33.53500     60066.98
diff-avx      30269.93         6.60551         6.46300        13.31100        32.51100     66806.68
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 16 | Kb/s Change: 33.31%
diff-sse      36456.27         5.47794         5.43900         8.03100        29.82300     14205.13
diff-avx      48967.07         4.07945         3.80700         5.98300        27.64700     18936.48
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 35 | Kb/s Change: 53.49%
diff-sse      19508.55        10.34083        10.94300        23.55100        38.14300     15564.93
diff-avx      30054.50         6.64666         6.71900        13.11900        31.74300     23890.98
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 101 | Kb/s Change: 51.86%
diff-sse       6450.05        31.03209        33.02300        56.83100        71.16700     14210.26
diff-avx       9773.60        20.52574        21.63100        40.19100        53.75900     21580.19
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 16 | Kb/s Change: 115.29%
diff-sse       8804.65        22.75742        25.59900        43.77500        57.34300      3413.52
diff-avx      18907.73        10.55792        11.26300        23.80700        39.16700      7348.90
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 35 | Kb/s Change: 80.33%
diff-sse       3883.73        51.59281        57.85500        84.99100       103.42300      3091.05
diff-avx       7003.52        28.56112        31.87100        51.19900        64.76700      5574.09
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 101 | Kb/s Change: 70.04%
diff-sse       1134.93       176.45675       192.51100       235.51900       262.14300      2503.71
diff-avx       1930.71       103.70039       114.68700       142.33500       154.62300      4257.37
--------------------------------------------------------------------------------------------------

===============================================one================================================
Key Size: 32B | Key Count: 16 | Kb/s Change: 0.97%
one-sse      70444.99         2.83806         2.78300         5.47100        26.62300     26898.43
one-avx      70589.98         2.82571         2.78300         5.47100        26.62300     27160.60
--------------------------------------------------------------------------------------------------
Key Size: 32B | Key Count: 35 | Kb/s Change: 0.98%
one-sse      57605.01         3.44909         3.21500         5.21500        26.87900     45622.72
one-avx      58170.67         3.43234         3.19900         5.21500        27.13500     46070.72
--------------------------------------------------------------------------------------------------
Key Size: 32B | Key Count: 101 | Kb/s Change: 2.18%
one-sse      35857.05         5.57616         5.37500         8.70300        30.33500     78787.46
one-avx      36572.35         5.46083         5.24700         8.19100        30.46300     80502.02
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 16 | Kb/s Change: 9.70%
one-sse      60675.57         3.29465         3.05500         4.92700        26.36700     23345.87
one-avx      66223.32         3.01574         2.83100         4.57500        25.85500     25609.80
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 35 | Kb/s Change: 16.96%
one-sse      45389.32         4.43897         4.22300         6.49500        28.54300     35992.31
one-avx      53285.05         3.75387         3.48700         5.59900        27.00700     42097.27
--------------------------------------------------------------------------------------------------
Key Size: 1KB | Key Count: 101 | Kb/s Change: 32.03%
one-sse      22562.12         8.85785         8.89500        20.35100        36.09500     49751.24
one-avx      29788.10         6.73381         6.59100        13.82300        33.02300     65685.08
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 16 | Kb/s Change: 80.44%
one-sse      25856.61         7.75498         8.09500        17.02300        33.79100     10024.49
one-avx      47011.03         4.24812         3.98300         6.20700        28.03100     18088.23
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 35 | Kb/s Change: 134.07%
one-sse      12522.46        15.95310        17.27900        33.53500        47.35900      9966.60
one-avx      29419.75         6.80751         6.87900        13.82300        32.38300     23328.94
--------------------------------------------------------------------------------------------------
Key Size: 10KB | Key Count: 101 | Kb/s Change: 144.82%
one-sse       3868.40        51.73798        55.29500        84.47900        96.25500      8515.02
one-avx       9449.50        21.15084        22.27100        41.72700        55.55100     20846.11
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 16 | Kb/s Change: 214.35%
one-sse       5588.73        35.84317        40.70300        63.74300        78.84700      2155.81
one-avx      17523.71        11.39751        12.35100        25.47100        39.67900      6776.75
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 35 | Kb/s Change: 167.33%
one-sse       2568.79        78.00155        88.06300       117.24700       133.11900      2039.48
one-avx       6867.05        29.14662        32.63900        52.99100        67.07100      5452.06
--------------------------------------------------------------------------------------------------
Key Size: 50KB | Key Count: 101 | Kb/s Change: 153.65%
one-sse        728.67       274.93407       296.95900       364.54300       430.07900      1606.06
one-avx       1849.08       108.06780       118.78300       149.50300       162.81500      4073.75
--------------------------------------------------------------------------------------------------
```

## **Notes**

One can see that AVX shows no benefit over SSE for the `BITOP NOT` operation (even some pessimization in certain cases) - I attribute that to the fact that there are a lot of loads/stores(unaligned for that matter) compared to only 1 logic instruction.

Another observation is the decrease of improvement when command is run with more keys - this happens for keys of big size. As we add more keys - there are more load instruction and I conjure they degrade the performance. Still - we gain a lot of speed over the compiler generated SSE.

Final note - both source keys and destination memory are unaligned. SIMD load instructions are more effective when load/store operation is done over memory aligned to the size of the SIMD register. We can't possibly benefit from aligning source keys as it would incur too much copies, but we can allocate aligned memory for the result before copying it to the destination key. Sadly, this did not add any benefit compared to the above benchmarks which I don't include for brevity.

## **Repro**
SSE: *add-commit-hash*
AVX: *add-commit-hash*
benchmark script: *add-repo-link*