### PR TITLE
Lp batch experiment

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -922,9 +922,13 @@ int hashTypeSet(redisDb *db, robj *o, sds field, sds value, int flags) {
         }
 
         if (!update) {
+            listpackEntry entries[2] = {
+                {.sval = (unsigned char*) field, .slen = sdslen(field)},
+                {.sval = (unsigned char*) value, .slen = sdslen(value)},
+            };
+
             /* Push new field/value pair onto the tail of the listpack */
-            zl = lpAppend(zl, (unsigned char*)field, sdslen(field));
-            zl = lpAppend(zl, (unsigned char*)value, sdslen(value));
+            zl = lpBatchAppend(zl, entries, 2);
         }
         o->ptr = zl;
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -564,6 +564,9 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
         lp = lpNew(prealloc);
         lp = lpBatchAppend(lp, entries, numEntries);
+
+        zfree(entries);
+
         raxInsert(s->rax,(unsigned char*)&rax_key,sizeof(rax_key),lp,NULL);
         /* The first entry we insert, has obviously the same fields of the
          * master entry. */
@@ -660,6 +663,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
     serverAssert(idx == numEntries);
 
     lp = lpBatchAppend(lp, entries, numEntries);
+    
+    zfree(entries);
 
     /* Insert back into the tree in order to update the listpack pointer. */
     if (ri.data != lp)

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -548,15 +548,21 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         if (server.stream_node_max_bytes > 0 && server.stream_node_max_bytes < prealloc) {
             prealloc = server.stream_node_max_bytes;
         }
-        lp = lpNew(prealloc);
-        lp = lpAppendInteger(lp,1); /* One item, the one we are adding. */
-        lp = lpAppendInteger(lp,0); /* Zero deleted so far. */
-        lp = lpAppendInteger(lp,numfields);
+
+        int numEntries = 3 + numfields + 1;
+        listpackEntry *entries = zmalloc(sizeof(listpackEntry)*numEntries);
+        entries[0].lval = 1; /* One item, the one we are adding. */
+        entries[1].lval = 0; /* Zero deleted so far. */
+        entries[2].lval = numfields;
         for (int64_t i = 0; i < numfields; i++) {
             sds field = argv[i*2]->ptr;
-            lp = lpAppend(lp,(unsigned char*)field,sdslen(field));
+            entries[i+3].sval = (unsigned char*)field;
+            entries[i+3].slen = sdslen(field);
         }
-        lp = lpAppendInteger(lp,0); /* Master entry zero terminator. */
+        entries[numfields+3].lval = 0; /* Master entry zero terminator. */
+
+        lp = lpNew(prealloc);
+        lp = lpBatchAppend(lp, entries, numEntries);
         raxInsert(s->rax,(unsigned char*)&rax_key,sizeof(rax_key),lp,NULL);
         /* The first entry we insert, has obviously the same fields of the
          * master entry. */
@@ -619,26 +625,36 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
      * in reverse order: we can just start from the end of the listpack, read
      * the entry, and jump back N times to seek the "flags" field to read
      * the stream full entry. */
-    lp = lpAppendInteger(lp,flags);
-    lp = lpAppendInteger(lp,id.ms - master_id.ms);
-    lp = lpAppendInteger(lp,id.seq - master_id.seq);
-    if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS))
-        lp = lpAppendInteger(lp,numfields);
-    for (int64_t i = 0; i < numfields; i++) {
-        sds field = argv[i*2]->ptr, value = argv[i*2+1]->ptr;
-        if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS))
-            lp = lpAppend(lp,(unsigned char*)field,sdslen(field));
-        lp = lpAppend(lp,(unsigned char*)value,sdslen(value));
-    }
-    /* Compute and store the lp-count field. */
-    int64_t lp_count = numfields;
-    lp_count += 3; /* Add the 3 fixed fields flags + ms-diff + seq-diff. */
+
+    /* 3 fixed fields flags + ms-diff + seq-diff; numfields and lp-count field */ 
+    int numEntries = 3 + numfields + 1;
     if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
         /* If the item is not compressed, it also has the fields other than
          * the values, and an additional num-fields field. */
-        lp_count += numfields+1;
+        numEntries += numfields + 1;
     }
-    lp = lpAppendInteger(lp,lp_count);
+    listpackEntry *entries = zmalloc(sizeof(listpackEntry)*numEntries);
+    int idx = 0;
+    entries[idx++].lval = flags;
+    entries[idx++].lval = id.ms - master_id.ms;
+    entries[idx++].lval = id.seq - master_id.seq;
+    if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS))
+        entries[idx++].lval = numfields;
+    for (int64_t i = 0; i < numfields; i++) {
+        sds field = argv[i*2]->ptr, value = argv[i*2+1]->ptr;
+        if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
+            entries[idx].sval = (unsigned char*)field;
+            entries[idx++].slen = sdslen(field);
+        }
+        entries[idx].sval = (unsigned char*)value;
+        entries[idx++].slen = sdslen(value);
+    }
+
+    /* The lp-count field doesn't count itself. */
+    const int64_t lp_count = numEntries - 1;
+    entries[idx++].lval = lp_count;
+
+    lp = lpBatchAppend(lp, entries, numEntries);
 
     /* Insert back into the tree in order to update the listpack pointer. */
     if (ri.data != lp)

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -548,25 +548,15 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         if (server.stream_node_max_bytes > 0 && server.stream_node_max_bytes < prealloc) {
             prealloc = server.stream_node_max_bytes;
         }
-
-        int numEntries = 3 + numfields + 1;
-        listpackEntry *entries = zmalloc(sizeof(listpackEntry)*numEntries);
-        memset(entries, 0, sizeof(listpackEntry)*numEntries);
-        entries[0].lval = 1; /* One item, the one we are adding. */
-        entries[1].lval = 0; /* Zero deleted so far. */
-        entries[2].lval = numfields;
+        lp = lpNew(prealloc);
+        lp = lpAppendInteger(lp,1); /* One item, the one we are adding. */
+        lp = lpAppendInteger(lp,0); /* Zero deleted so far. */
+        lp = lpAppendInteger(lp,numfields);
         for (int64_t i = 0; i < numfields; i++) {
             sds field = argv[i*2]->ptr;
-            entries[i+3].sval = (unsigned char*)field;
-            entries[i+3].slen = sdslen(field);
+            lp = lpAppend(lp,(unsigned char*)field,sdslen(field));
         }
-        entries[numfields+3].lval = 0; /* Master entry zero terminator. */
-
-        lp = lpNew(prealloc);
-        lp = lpBatchAppend(lp, entries, numEntries);
-
-        zfree(entries);
-
+        lp = lpAppendInteger(lp,0); /* Master entry zero terminator. */
         raxInsert(s->rax,(unsigned char*)&rax_key,sizeof(rax_key),lp,NULL);
         /* The first entry we insert, has obviously the same fields of the
          * master entry. */
@@ -629,42 +619,26 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
      * in reverse order: we can just start from the end of the listpack, read
      * the entry, and jump back N times to seek the "flags" field to read
      * the stream full entry. */
-
-    /* 3 fixed fields flags + ms-diff + seq-diff; numfields values and lp-count field */ 
-    int numEntries = 3 + numfields + 1;
+    lp = lpAppendInteger(lp,flags);
+    lp = lpAppendInteger(lp,id.ms - master_id.ms);
+    lp = lpAppendInteger(lp,id.seq - master_id.seq);
+    if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS))
+        lp = lpAppendInteger(lp,numfields);
+    for (int64_t i = 0; i < numfields; i++) {
+        sds field = argv[i*2]->ptr, value = argv[i*2+1]->ptr;
+        if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS))
+            lp = lpAppend(lp,(unsigned char*)field,sdslen(field));
+        lp = lpAppend(lp,(unsigned char*)value,sdslen(value));
+    }
+    /* Compute and store the lp-count field. */
+    int64_t lp_count = numfields;
+    lp_count += 3; /* Add the 3 fixed fields flags + ms-diff + seq-diff. */
     if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
         /* If the item is not compressed, it also has the fields other than
          * the values, and an additional num-fields field. */
-        numEntries += numfields + 1;
+        lp_count += numfields+1;
     }
-    listpackEntry *entries = zmalloc(sizeof(listpackEntry)*numEntries);
-    memset(entries, 0, sizeof(listpackEntry)*numEntries);
-
-    int idx = 0;
-    entries[idx++].lval = flags;
-    entries[idx++].lval = id.ms - master_id.ms;
-    entries[idx++].lval = id.seq - master_id.seq;
-    if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS))
-        entries[idx++].lval = numfields;
-    for (int64_t i = 0; i < numfields; i++) {
-        sds field = argv[i*2]->ptr, value = argv[i*2+1]->ptr;
-        if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
-            entries[idx].sval = (unsigned char*)field;
-            entries[idx++].slen = sdslen(field);
-        }
-        entries[idx].sval = (unsigned char*)value;
-        entries[idx++].slen = sdslen(value);
-    }
-
-    /* The lp-count field doesn't count itself. */
-    const int64_t lp_count = numEntries - 1;
-    entries[idx++].lval = lp_count;
-
-    serverAssert(idx == numEntries);
-
-    lp = lpBatchAppend(lp, entries, numEntries);
-    
-    zfree(entries);
+    lp = lpAppendInteger(lp,lp_count);
 
     /* Insert back into the tree in order to update the listpack pointer. */
     if (ri.data != lp)

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -551,6 +551,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 
         int numEntries = 3 + numfields + 1;
         listpackEntry *entries = zmalloc(sizeof(listpackEntry)*numEntries);
+        memset(entries, 0, sizeof(listpackEntry)*numEntries);
         entries[0].lval = 1; /* One item, the one we are adding. */
         entries[1].lval = 0; /* Zero deleted so far. */
         entries[2].lval = numfields;
@@ -626,7 +627,7 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
      * the entry, and jump back N times to seek the "flags" field to read
      * the stream full entry. */
 
-    /* 3 fixed fields flags + ms-diff + seq-diff; numfields and lp-count field */ 
+    /* 3 fixed fields flags + ms-diff + seq-diff; numfields values and lp-count field */ 
     int numEntries = 3 + numfields + 1;
     if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
         /* If the item is not compressed, it also has the fields other than
@@ -634,6 +635,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
         numEntries += numfields + 1;
     }
     listpackEntry *entries = zmalloc(sizeof(listpackEntry)*numEntries);
+    memset(entries, 0, sizeof(listpackEntry)*numEntries);
+
     int idx = 0;
     entries[idx++].lval = flags;
     entries[idx++].lval = id.ms - master_id.ms;
@@ -653,6 +656,8 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
     /* The lp-count field doesn't count itself. */
     const int64_t lp_count = numEntries - 1;
     entries[idx++].lval = lp_count;
+
+    serverAssert(idx == numEntries);
 
     lp = lpBatchAppend(lp, entries, numEntries);
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1452,8 +1452,29 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 
             /* Remove and re-insert when score changed. */
             if (score != curscore) {
-                zobj->ptr = zzlDelete(zobj->ptr,eptr);
-                zobj->ptr = zzlInsert(zobj->ptr,ele,score);
+                unsigned char *sptr = lpNext(zobj->ptr, eptr);
+
+                /* If we are updating the score of the last element(i.e the one
+                 * with the biggest score) with bigger score, then it's 
+                 * enough to just replace its score. This will preserve the
+                 * ordering and save us some iterations over the listpack. */
+                int is_last = (lpNext(zobj->ptr, sptr) == NULL);
+                if (is_last && score > curscore) {
+                    char scorebuf[MAX_D2STRING_CHARS];
+                    int scorelen = 0;
+                    long long lscore;
+                    int score_is_long = double2ll(score, &lscore);
+                    if (!score_is_long)
+                        scorelen = d2string(scorebuf,sizeof(scorebuf),score);
+
+                    if (score_is_long)
+                        zobj->ptr = lpReplaceInteger(zobj->ptr, &sptr, lscore);
+                    else
+                        zobj->ptr = lpReplace(zobj->ptr, &sptr, (unsigned char*)scorebuf, scorelen);
+                } else {
+                    zobj->ptr = zzlDelete(zobj->ptr,eptr);
+                    zobj->ptr = zzlInsert(zobj->ptr,ele,score);
+                }
                 *out_flags |= ZADD_OUT_UPDATED;
             }
             return 1;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1452,29 +1452,8 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 
             /* Remove and re-insert when score changed. */
             if (score != curscore) {
-                unsigned char *sptr = lpNext(zobj->ptr, eptr);
-
-                /* If we are updating the score of the last element(i.e the one
-                 * with the biggest score) with bigger score, then it's 
-                 * enough to just replace its score. This will preserve the
-                 * ordering and save us some iterations over the listpack. */
-                int is_last = (lpNext(zobj->ptr, sptr) == NULL);
-                if (is_last && score > curscore) {
-                    char scorebuf[MAX_D2STRING_CHARS];
-                    int scorelen = 0;
-                    long long lscore;
-                    int score_is_long = double2ll(score, &lscore);
-                    if (!score_is_long)
-                        scorelen = d2string(scorebuf,sizeof(scorebuf),score);
-
-                    if (score_is_long)
-                        zobj->ptr = lpReplaceInteger(zobj->ptr, &sptr, lscore);
-                    else
-                        zobj->ptr = lpReplace(zobj->ptr, &sptr, (unsigned char*)scorebuf, scorelen);
-                } else {
-                    zobj->ptr = zzlDelete(zobj->ptr,eptr);
-                    zobj->ptr = zzlInsert(zobj->ptr,ele,score);
-                }
+                zobj->ptr = zzlDelete(zobj->ptr,eptr);
+                zobj->ptr = zzlInsert(zobj->ptr,ele,score);
                 *out_flags |= ZADD_OUT_UPDATED;
             }
             return 1;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1074,29 +1074,29 @@ unsigned char *zzlDelete(unsigned char *zl, unsigned char *eptr) {
 }
 
 unsigned char *zzlInsertAt(unsigned char *zl, unsigned char *eptr, sds ele, double score) {
-    unsigned char *sptr;
     char scorebuf[MAX_D2STRING_CHARS];
     int scorelen = 0;
     long long lscore;
     int score_is_long = double2ll(score, &lscore);
     if (!score_is_long)
         scorelen = d2string(scorebuf,sizeof(scorebuf),score);
-    if (eptr == NULL) {
-        zl = lpAppend(zl,(unsigned char*)ele,sdslen(ele));
-        if (score_is_long)
-            zl = lpAppendInteger(zl,lscore);
-        else
-            zl = lpAppend(zl,(unsigned char*)scorebuf,scorelen);
-    } else {
-        /* Insert member before the element 'eptr'. */
-        zl = lpInsertString(zl,(unsigned char*)ele,sdslen(ele),eptr,LP_BEFORE,&sptr);
 
-        /* Insert score after the member. */
-        if (score_is_long)
-            zl = lpInsertInteger(zl,lscore,sptr,LP_AFTER,NULL);
-        else
-            zl = lpInsertString(zl,(unsigned char*)scorebuf,scorelen,sptr,LP_AFTER,NULL);
+    listpackEntry entries[2];
+    entries[0].sval = (unsigned char*)ele;
+    entries[0].slen = sdslen(ele);
+    if (score_is_long) {
+        entries[1].sval = NULL;
+        entries[1].lval = lscore;
+    } else {
+        entries[1].sval = (unsigned char*)scorebuf;
+        entries[1].slen = scorelen;
     }
+
+    if (eptr == NULL)
+        zl = lpBatchAppend(zl, entries, 2);
+    else
+        zl = lpBatchInsert(zl, eptr, LP_BEFORE, entries, 2, NULL);
+
     return zl;
 }
 


### PR DESCRIPTION
Use lpBatchAppend/Insert instead of multiple calls to lpAppend/Insert wherever possible

# Hash

```
$ memtier_benchmark --test-time 60 --distinct-client-seed "--data-size" "64" --command="DEL key" --command "HSET key field:1 __data__ field:2 __data__ field:3 __data__ field:4 __data__ field:5 __data__ field:6 __data__ field:7 __data__ field:8 __data__ field:9 __data__ field:10 __data__ field:11 __data__ field:12 __data__ field:13 __data__ field:14 __data__ field:15 __data__ field:16 __data__ field:17 __data__ field:18 __data__ field:19 __data__ field:20 __data__ field:21 __data__ field:22 __data__ field:23 __data__ field:24 __data__ field:25 __data__ field:26 __data__ field:27 __data__ field:28 __data__ field:29 __data__ field:30 __data__ field:31 __data__ field:32 __data__ field:33 __data__ field:34 __data__ field:35 __data__ field:36 __data__ field:37 __data__ field:38 __data__ field:39 __data__ field:40 __data__ field:41 __data__ field:42 __data__ field:43 __data__ field:44 __data__ field:45 __data__ field:46 __data__ field:47 __data__ field:48 __data__ field:49 __data__ field:50 __data__" -c 50 -t 4 --hide-histogram 

========================================================================================================
Type                Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------------
Hsets-before       49539.14         2.03172         2.03900         3.03900         3.79100    206598.42
Hsets-after        50346.67         1.99950         1.99900         3.03900         3.85500    209966.12
```

# stream

```
memtier_benchmark "--data-size" "100" --command "XADD __key__ MAXLEN ~ 5 * field __data__ field __data__ field __data__ field __data__ field __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 1000000 --test-time 60 -c 50 -t 4 --hide-histogram
```

## no pipelining

```
==================================================================================================
Type              Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Xadds-before      168635.18         1.18610         1.18300         1.93500         2.51100    112954.10
Xadds-after       167506.27         1.19409         1.19100         1.94300         2.51100    112197.94
```

## --pipeline 5

```
==================================================================================================
Type              Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Xadds-before      400853.08         2.49440         2.43100         3.95100         5.18300    268496.78
Xadds-after       393134.24         2.54335         2.47900         3.98300         4.57500    263326.57
```

## --pipeline 10

```
==================================================================================================
Type              Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Xadds-before      467683.38         4.27567         4.19100         6.04700         7.48700    313260.56
Xadds-after       456249.25         4.38281         4.31900         6.30300         7.26300    305601.83
```

# zset

Show a little bit of improvement for the insert case and seemingly little difference for the append case.

## Insert 

### Script

```
./src/redis-cli flushall
./src/redis-cli zadd key 100000 a 200000 b 300000 c 400000 d 500000 e 600000 f
./src/redis-cli -p 5002 flushall
./src/redis-cli -p 5002 zadd key 100000 a 200000 b 300000 c 400000 d 500000 e 600000 f

echo UNSTABLE: && memtier_benchmark --command="zadd key __key__ c" --key-prefix="" --command-key-pattern=S --hide-histogram --key-minimum=300001 --test-time 180 --pipeline 10 | tail -n 2 | head -n 1
echo BATCH: && memtier_benchmark --command="zadd key __key__ c" --key-prefix="" --command-key-pattern=S --hide-histogram --key-minimum=300001 --test-time 180 --pipeline 10 --port 5002 | tail -n 2 | head -n 1
``` 

### Results

```
==================================================================================================
Type              Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Zadds-before      1249850.63         1.59968         1.59100         2.70300         3.39100     56606.65
Zadds-after       1287818.39         1.55250         1.53500         2.71900         3.31100     58349.31
```

## Append

### Script

```
./src/redis-cli flushall
./src/redis-cli zadd key 100000 a 200000 b 300000 c 400000 d 500000 e 600000 f
./src/redis-cli -p 5002 flushall
./src/redis-cli -p 5002 zadd key 100000 a 200000 b 300000 c 400000 d 500000 e 600000 f

echo UNSTABLE: && memtier_benchmark --command="zadd key __key__ c" --key-prefix="" --command-key-pattern=S --hide-histogram --key-minimum=600001 --test-time 180 --pipeline 10 | tail -n 2 | head -n 1
echo BATCH: && memtier_benchmark --command="zadd key __key__ c" --key-prefix="" --command-key-pattern=S --hide-histogram --key-minimum=600001 --test-time 180 --pipeline 10 --port 5002 | tail -n 2 | head -n 1
```

### Results

```
==================================================================================================
Type               Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Zadds-before       1249664.05         1.59991         1.58300         2.81500         3.40700     56923.61
Zadds-after        1258994.60         1.58803         1.56700         2.86300         3.37500     57351.86
```

## Append optimization ( **REVERTED** )

Managed to optimize the append case (updating the score of the biggest element with a bigger score) with commit [6036cc7](https://github.com/minchopaskal/redis/pull/4/commits/6036cc701dfa74925726b71efe442fb4cc837532)

### Script

The same as above

### Results

```
==================================================================================================
Type               Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
append-before       1240420.18         1.61181         1.59100         2.86300         3.34300     55891.71
append-after        1396518.14         1.43161         1.39100         2.65500         3.08700     63056.35
```