### PR TITLE
Client compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
     - name: make
       # Fail build if there are warnings
       # build with TLS just for compilation coverage
-      run: make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
+      run: |
+        sudo apt-get install -y libzstd-dev
+        make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
     - name: test
       run: |
         sudo apt-get install tcl8.6 tclx zlib1g-dev
@@ -29,7 +31,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: make
         # build with TLS module just for compilation coverage
-        run: make SANITIZER=address REDIS_CFLAGS='-Werror -DDEBUG_ASSERTIONS -DREDIS_TEST' BUILD_TLS=module
+        run: |
+          sudo apt-get install -y libzstd-dev
+          make SANITIZER=address REDIS_CFLAGS='-Werror -DDEBUG_ASSERTIONS -DREDIS_TEST' BUILD_TLS=module
       - name: testprep
         run: sudo apt-get install tcl8.6 tclx zlib1g-dev -y
       - name: test
@@ -44,7 +48,7 @@ jobs:
       run: |
         sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
         sed -i 's|http://security.debian.org|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
-        apt-get update && apt-get install -y build-essential zlib1g-dev
+        apt-get update && apt-get install -y build-essential zlib1g-dev libzstd-dev
         make REDIS_CFLAGS='-Werror'
 
   build-macos-latest:
@@ -54,7 +58,9 @@ jobs:
     - name: make
       # Fail build if there are warnings
       # build with TLS just for compilation coverage
-      run: make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
+      run: |
+        brew install zstd
+        make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
 
   build-32bit:
     runs-on: ubuntu-latest
@@ -63,7 +69,7 @@ jobs:
     - name: make
       run: |
         sudo dpkg --add-architecture i386
-        sudo apt-get update && sudo apt-get install libc6-dev-i386 gcc-multilib g++-multilib zlib1g-dev:i386
+        sudo apt-get update && sudo apt-get install libc6-dev-i386 gcc-multilib g++-multilib zlib1g-dev:i386 libzstd-dev:i386
         make REDIS_CFLAGS='-Werror' 32bit
 
   build-libc-malloc:
@@ -71,7 +77,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: make
-      run: make REDIS_CFLAGS='-Werror' MALLOC=libc
+      run: |
+        sudo apt-get install -y libzstd-dev
+        make REDIS_CFLAGS='-Werror' MALLOC=libc
 
   build-centos-jemalloc:
     runs-on: ubuntu-latest
@@ -80,7 +88,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: make
       run: |
-        dnf -y install which gcc gcc-c++ make zlib-devel
+        dnf -y install which gcc gcc-c++ make zlib-devel libzstd-devel
         make REDIS_CFLAGS='-Werror'
 
   build-old-chain-jemalloc:
@@ -97,7 +105,7 @@ jobs:
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
-        apt-get install -y make gcc-4.8 g++-4.8 zlib1g-dev
+        apt-get install -y make gcc-4.8 g++-4.8 zlib1g-dev libzstd-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
         make CC=gcc REDIS_CFLAGS='-Werror'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       run: make REDIS_CFLAGS='-Werror' BUILD_TLS=yes
     - name: test
       run: |
-        sudo apt-get install tcl8.6 tclx
+        sudo apt-get install tcl8.6 tclx zlib1g-dev
         ./runtest --verbose --tags -slow --dump-logs
     - name: validate commands.def up to date
       run: |
@@ -31,7 +31,7 @@ jobs:
         # build with TLS module just for compilation coverage
         run: make SANITIZER=address REDIS_CFLAGS='-Werror -DDEBUG_ASSERTIONS -DREDIS_TEST' BUILD_TLS=module
       - name: testprep
-        run: sudo apt-get install tcl8.6 tclx -y
+        run: sudo apt-get install tcl8.6 tclx zlib1g-dev -y
       - name: test
         run: ./runtest --verbose --tags -slow --dump-logs
 
@@ -44,7 +44,7 @@ jobs:
       run: |
         sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
         sed -i 's|http://security.debian.org|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
-        apt-get update && apt-get install -y build-essential
+        apt-get update && apt-get install -y build-essential zlib1g-dev
         make REDIS_CFLAGS='-Werror'
 
   build-macos-latest:
@@ -62,7 +62,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: make
       run: |
-        sudo apt-get update && sudo apt-get install libc6-dev-i386 gcc-multilib g++-multilib
+        sudo dpkg --add-architecture i386
+        sudo apt-get update && sudo apt-get install libc6-dev-i386 gcc-multilib g++-multilib zlib1g-dev:i386
         make REDIS_CFLAGS='-Werror' 32bit
 
   build-libc-malloc:
@@ -79,7 +80,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: make
       run: |
-        dnf -y install which gcc gcc-c++ make
+        dnf -y install which gcc gcc-c++ make zlib-devel
         make REDIS_CFLAGS='-Werror'
 
   build-old-chain-jemalloc:
@@ -96,7 +97,7 @@ jobs:
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
-        apt-get install -y make gcc-4.8 g++-4.8
+        apt-get install -y make gcc-4.8 g++-4.8 zlib1g-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
         make CC=gcc REDIS_CFLAGS='-Werror'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,8 @@ jobs:
       run: |
         sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
         sed -i 's|http://security.debian.org|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
-        apt-get update && apt-get install -y build-essential zlib1g-dev libzstd-dev
+        echo "deb http://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+        apt-get update && apt-get install -y build-essential zlib1g-dev libzstd-dev/buster-backports
         make REDIS_CFLAGS='-Werror'
 
   build-macos-latest:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -359,7 +359,7 @@ jobs:
       # replication and some tests start to fail because of timing errors.
       # This is similar to why we run tsan with only 1 client which is even
       # more extreme case
-      run: ./runtest --clients 8 --config io-threads 4 --config repl-compression 1 --compression --accurate --verbose --tags "repl network iothreads psync2" --dump-logs ${{github.event.inputs.test_args}}
+      run: ./runtest --clients 4 --config io-threads 4 --config repl-compression 1 --compression --accurate --verbose --tags "repl network iothreads psync2" --dump-logs ${{github.event.inputs.test_args}}
     - name: cluster tests
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
       run: ./runtest-cluster --config io-threads 4 --config repl-compression 1 --compression ${{github.event.inputs.cluster_test_args}}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -355,7 +355,11 @@ jobs:
       run: sudo apt-get install tcl8.6 tclx
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
-      run: ./runtest --config io-threads 4 --config repl-compression 1 --compression --accurate --verbose --tags "repl network iothreads psync2" --dump-logs ${{github.event.inputs.test_args}}
+      # Running with less than default(16) clients as compression slows down
+      # replication and some tests start to fail because of timing errors.
+      # This is similar to why we run tsan with only 1 client which is even
+      # more extreme case
+      run: ./runtest --clients 8 --config io-threads 4 --config repl-compression 1 --compression --accurate --verbose --tags "repl network iothreads psync2" --dump-logs ${{github.event.inputs.test_args}}
     - name: cluster tests
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
       run: ./runtest-cluster --config io-threads 4 ${{github.event.inputs.cluster_test_args}}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -362,7 +362,7 @@ jobs:
       run: ./runtest --clients 8 --config io-threads 4 --config repl-compression 1 --compression --accurate --verbose --tags "repl network iothreads psync2" --dump-logs ${{github.event.inputs.test_args}}
     - name: cluster tests
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
-      run: ./runtest-cluster --config io-threads 4 ${{github.event.inputs.cluster_test_args}}
+      run: ./runtest-cluster --config io-threads 4 --config repl-compression 1 --compression ${{github.event.inputs.cluster_test_args}}
 
   test-ubuntu-reclaim-cache:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,7 +11,7 @@ on:
     inputs:
       skipjobs:
         description: 'jobs to skip (delete the ones you wanna keep, do not leave empty)'
-        default: 'valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,centos,malloc,specific,fortify,reply-schema,oldTC,defrag,vectorset'
+        default: 'valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,centos,malloc,specific,fortify,reply-schema,oldTC,defrag,vectorset,compression'
       skiptests:
         description: 'tests to skip (delete the ones you wanna keep, do not leave empty)'
         default: 'redis,modules,sentinel,cluster,unittest'
@@ -90,7 +90,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        apt-get update && apt-get install -y make gcc g++
+        apt-get update && apt-get install -y make gcc g++ zlib1g-dev
         make CC=gcc REDIS_CFLAGS='-Werror -DREDIS_TEST -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3'
     - name: testprep
       run: sudo apt-get install -y tcl8.6 tclx procps
@@ -130,7 +130,7 @@ jobs:
     - name: make
       run: make MALLOC=libc REDIS_CFLAGS='-Werror'
     - name: testprep
-      run: sudo apt-get install tcl8.6 tclx
+      run: sudo apt-get install tcl8.6 tclx zlib1g-dev
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
       run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -197,7 +197,8 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        sudo apt-get update && sudo apt-get install libc6-dev-i386 g++ gcc-multilib g++-multilib
+        sudo dpkg --add-architecture i386
+        sudo apt-get update && sudo apt-get install libc6-dev-i386 g++ gcc-multilib g++-multilib zlib1g-dev:i386
         make 32bit REDIS_CFLAGS='-Werror -DREDIS_TEST'
         make -C tests/modules 32bit # the script below doesn't have an argument, we must build manually ahead of time
     - name: testprep
@@ -240,7 +241,7 @@ jobs:
         make BUILD_TLS=yes REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
-        sudo apt-get install tcl8.6 tclx tcl-tls
+        sudo apt-get install tcl8.6 tclx tcl-tls zlib1g-dev
         ./utils/gen-test-certs.sh
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
@@ -280,7 +281,7 @@ jobs:
         make BUILD_TLS=yes REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
-        sudo apt-get install tcl8.6 tclx tcl-tls
+        sudo apt-get install tcl8.6 tclx tcl-tls zlib1g-dev
         ./utils/gen-test-certs.sh
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
@@ -319,10 +320,42 @@ jobs:
       run: |
         make REDIS_CFLAGS='-Werror'
     - name: testprep
-      run: sudo apt-get install tcl8.6 tclx
+      run: sudo apt-get install tcl8.6 tclx zlib1g-dev
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
       run: ./runtest --config io-threads 4 --accurate --verbose --tags "network iothreads psync2 repl failover" --dump-logs ${{github.event.inputs.test_args}}
+    - name: cluster tests
+      if: true && !contains(github.event.inputs.skiptests, 'cluster')
+      run: ./runtest-cluster --config io-threads 4 ${{github.event.inputs.cluster_test_args}}
+
+  test-ubuntu-client-compression:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'redis/redis')) &&
+      !contains(github.event.inputs.skipjobs, 'compression')
+    timeout-minutes: 14400
+    steps:
+    - name: prep
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "GITHUB_REPOSITORY=${{github.event.inputs.use_repo}}" >> $GITHUB_ENV
+        echo "GITHUB_HEAD_REF=${{github.event.inputs.use_git_ref}}" >> $GITHUB_ENV
+        echo "skipjobs: ${{github.event.inputs.skipjobs}}"
+        echo "skiptests: ${{github.event.inputs.skiptests}}"
+        echo "test_args: ${{github.event.inputs.test_args}}"
+        echo "cluster_test_args: ${{github.event.inputs.cluster_test_args}}"
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ env.GITHUB_REPOSITORY }}
+        ref: ${{ env.GITHUB_HEAD_REF }}
+    - name: make
+      run: |
+        make REDIS_CFLAGS='-Werror'
+    - name: testprep
+      run: sudo apt-get install tcl8.6 tclx
+    - name: test
+      if: true && !contains(github.event.inputs.skiptests, 'redis')
+      run: ./runtest --config io-threads 4 --config repl-compression 1 --compression --accurate --verbose --tags "repl network iothreads psync2" --dump-logs ${{github.event.inputs.test_args}}
     - name: cluster tests
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
       run: ./runtest-cluster --config io-threads 4 ${{github.event.inputs.cluster_test_args}}
@@ -430,7 +463,7 @@ jobs:
     - name: testprep
       run: |
         sudo apt-get update
-        sudo apt-get install tcl8.6 tclx valgrind g++ -y
+        sudo apt-get install tcl8.6 tclx valgrind g++ zlib1g-dev -y
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
       # Note that valgrind's overhead doesn't pair well with io-threads so we
@@ -463,7 +496,7 @@ jobs:
     - name: testprep
       run: |
         sudo apt-get update
-        sudo apt-get install tcl8.6 tclx valgrind -y
+        sudo apt-get install tcl8.6 tclx valgrind zlib1g-dev -y
     - name: unittest
       if: true && !contains(github.event.inputs.skiptests, 'unittest')
       run: |
@@ -495,7 +528,7 @@ jobs:
     - name: testprep
       run: |
         sudo apt-get update
-        sudo apt-get install tcl8.6 tclx valgrind g++ -y
+        sudo apt-get install tcl8.6 tclx valgrind g++ zlib1g-dev -y
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
       run: ./runtest --valgrind --tags -iothreads --no-latency --verbose --clients 1 --timeout 2400 --dump-logs ${{github.event.inputs.test_args}}
@@ -525,7 +558,7 @@ jobs:
     - name: testprep
       run: |
         sudo apt-get update
-        sudo apt-get install tcl8.6 tclx valgrind -y
+        sudo apt-get install tcl8.6 tclx valgrind zlib1g-dev -y
     - name: unittest
       if: true && !contains(github.event.inputs.skiptests, 'unittest')
       run: |
@@ -562,7 +595,7 @@ jobs:
       - name: testprep
         run: |
           sudo apt-get update
-          sudo apt-get install tcl8.6 tclx -y
+          sudo apt-get install tcl8.6 tclx zlib1g-dev -y
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'redis')
         run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -603,7 +636,7 @@ jobs:
       - name: testprep
         run: |
           sudo apt-get update
-          sudo apt-get install tcl8.6 tclx -y
+          sudo apt-get install tcl8.6 tclx zlib1g-dev -y
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'redis')
         run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -647,7 +680,7 @@ jobs:
       - name: testprep
         run: |
           sudo apt-get update
-          sudo apt-get install tcl8.6 tclx -y
+          sudo apt-get install tcl8.6 tclx zlib1g-dev -y
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'redis')
         run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -694,7 +727,7 @@ jobs:
       - name: testprep
         run: |
           sudo apt-get update
-          sudo apt-get install tcl8.6 tclx -y
+          sudo apt-get install tcl8.6 tclx zlib1g-dev -y
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'redis')
         run: ./runtest --tsan --clients 1 --config io-threads 4 --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
@@ -728,7 +761,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        dnf -y install which gcc make g++
+        dnf -y install which gcc make g++ zlib-devel
         make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
@@ -767,7 +800,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        dnf -y install which gcc make openssl-devel openssl g++
+        dnf -y install which gcc make openssl-devel openssl g++ zlib-devel
         make BUILD_TLS=module REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
@@ -810,7 +843,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        dnf -y install which gcc make openssl-devel openssl g++
+        dnf -y install which gcc make openssl-devel openssl g++ zlib-devel
         make BUILD_TLS=module REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
@@ -990,7 +1023,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-          apk add build-base
+          apk add build-base zlib-dev
           make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: apk add tcl procps tclx
@@ -1026,7 +1059,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-          apk add build-base
+          apk add build-base zlib-dev
           make REDIS_CFLAGS='-Werror' USE_JEMALLOC=no CFLAGS=-DUSE_MALLOC_USABLE_SIZE
     - name: testprep
       run: apk add tcl procps tclx
@@ -1063,7 +1096,7 @@ jobs:
     - name: make
       run: make REDIS_CFLAGS='-Werror -DLOG_REQ_RES'
     - name: testprep
-      run: sudo apt-get install tcl8.6 tclx
+      run: sudo apt-get install tcl8.6 tclx zlib1g-dev
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
       run: ./runtest --log-req-res --no-latency --dont-clean --force-resp3 --tags -slow --verbose --dump-logs  ${{github.event.inputs.test_args}}
@@ -1110,7 +1143,7 @@ jobs:
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
-        apt-get install -y make gcc-4.8 g++-4.8
+        apt-get install -y make gcc-4.8 g++-4.8 zlib1g-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
         make CC=gcc REDIS_CFLAGS='-Werror'
@@ -1156,7 +1189,7 @@ jobs:
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
-        apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev
+        apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev zlib1g-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
         make CC=gcc CXX=g++ BUILD_TLS=module REDIS_CFLAGS='-Werror'
@@ -1207,7 +1240,7 @@ jobs:
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
-        apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev
+        apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev zlib1g-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
         make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror'
@@ -1251,7 +1284,7 @@ jobs:
     - name: make
       run: make SANITIZER=address DEBUG_DEFRAG=force REDIS_CFLAGS='-Werror'
     - name: testprep
-      run: sudo apt-get install tcl8.6 tclx
+      run: sudo apt-get install tcl8.6 tclx zlib1g-dev
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
       run: ./runtest --debug-defrag --verbose --clients 1 ${{github.event.inputs.test_args}}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -52,7 +52,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: |
+        sudo apt-get install -y libzstd-dev
+        make REDIS_CFLAGS='-Werror -DREDIS_TEST'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -90,7 +92,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        apt-get update && apt-get install -y make gcc g++ zlib1g-dev
+        apt-get update && apt-get install -y make gcc g++ zlib1g-dev libzstd-dev
         make CC=gcc REDIS_CFLAGS='-Werror -DREDIS_TEST -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3'
     - name: testprep
       run: sudo apt-get install -y tcl8.6 tclx procps
@@ -128,7 +130,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make MALLOC=libc REDIS_CFLAGS='-Werror'
+      run: |
+        sudo apt-get install -y libzstd-dev
+        make MALLOC=libc REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx zlib1g-dev
     - name: test
@@ -162,7 +166,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make MALLOC=libc CFLAGS=-DNO_MALLOC_USABLE_SIZE REDIS_CFLAGS='-Werror'
+      run: |
+        sudo apt-get install -y libzstd-dev
+        make MALLOC=libc CFLAGS=-DNO_MALLOC_USABLE_SIZE REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
     - name: test
@@ -198,7 +204,7 @@ jobs:
     - name: make
       run: |
         sudo dpkg --add-architecture i386
-        sudo apt-get update && sudo apt-get install libc6-dev-i386 g++ gcc-multilib g++-multilib zlib1g-dev:i386
+        sudo apt-get update && sudo apt-get install libc6-dev-i386 g++ gcc-multilib g++-multilib zlib1g-dev:i386 libzstd-dev:i386
         make 32bit REDIS_CFLAGS='-Werror -DREDIS_TEST'
         make -C tests/modules 32bit # the script below doesn't have an argument, we must build manually ahead of time
     - name: testprep
@@ -238,6 +244,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
+        sudo apt-get install -y libzstd-dev
         make BUILD_TLS=yes REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
@@ -278,6 +285,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
+        sudo apt-get install -y libzstd-dev
         make BUILD_TLS=yes REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
@@ -318,6 +326,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
+        sudo apt-get install -y libzstd-dev
         make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx zlib1g-dev
@@ -350,6 +359,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
+        sudo apt-get install -y libzstd-dev
         make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx
@@ -386,6 +396,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
+        sudo apt-get install -y libzstd-dev
         make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
@@ -463,7 +474,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: |
+        sudo apt-get update && sudo apt-get install -y libzstd-dev
+        make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST'
     - name: testprep
       run: |
         sudo apt-get update
@@ -496,7 +509,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: |
+        sudo apt-get update && sudo apt-get install -y libzstd-dev
+        make valgrind REDIS_CFLAGS='-Werror -DREDIS_TEST'
     - name: testprep
       run: |
         sudo apt-get update
@@ -528,7 +543,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror'
+      run: |
+        sudo apt-get update && sudo apt-get install -y libzstd-dev
+        make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         sudo apt-get update
@@ -558,7 +575,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror'
+      run: |
+        sudo apt-get update && sudo apt-get install -y libzstd-dev
+        make valgrind CFLAGS="-DNO_MALLOC_USABLE_SIZE -DREDIS_TEST" REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
         sudo apt-get update
@@ -595,7 +614,9 @@ jobs:
           repository: ${{ env.GITHUB_REPOSITORY }}
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
-        run: make SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS'
+        run: |
+          sudo apt-get install -y libzstd-dev
+          make SANITIZER=address REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS'
       - name: testprep
         run: |
           sudo apt-get update
@@ -636,7 +657,9 @@ jobs:
           repository: ${{ env.GITHUB_REPOSITORY }}
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
-        run: make SANITIZER=memory REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS'
+        run: |
+          sudo apt-get install -y libzstd-dev
+          make SANITIZER=memory REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS'
       - name: testprep
         run: |
           sudo apt-get update
@@ -680,7 +703,9 @@ jobs:
           repository: ${{ env.GITHUB_REPOSITORY }}
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
-        run: make SANITIZER=undefined REDIS_CFLAGS='-DREDIS_TEST -Werror' SKIP_VEC_SETS=yes LUA_DEBUG=yes # we (ab)use this flow to also check Lua C API violations
+        run: |
+          sudo apt-get install -y libzstd-dev
+          make SANITIZER=undefined REDIS_CFLAGS='-DREDIS_TEST -Werror' SKIP_VEC_SETS=yes LUA_DEBUG=yes # we (ab)use this flow to also check Lua C API violations
       - name: testprep
         run: |
           sudo apt-get update
@@ -727,7 +752,9 @@ jobs:
       - name: make
         # TODO Investigate why jemalloc with clang TSan crash on start;
         # with gcc TSan, jemalloc works modulo sentinel tests hanging.
-        run: make SANITIZER=thread USE_JEMALLOC=no REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS'
+        run: |
+          sudo apt-get install -y libzstd-dev
+          make SANITIZER=thread USE_JEMALLOC=no REDIS_CFLAGS='-DREDIS_TEST -Werror -DDEBUG_ASSERTIONS'
       - name: testprep
         run: |
           sudo apt-get update
@@ -765,7 +792,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        dnf -y install which gcc make g++ zlib-devel
+        dnf -y install which gcc make g++ zlib-devel libzstd-devel
         make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
@@ -804,7 +831,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        dnf -y install which gcc make openssl-devel openssl g++ zlib-devel
+        dnf -y install which gcc make openssl-devel openssl g++ zlib-devel libzstd-devel
         make BUILD_TLS=module REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
@@ -847,7 +874,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-        dnf -y install which gcc make openssl-devel openssl g++ zlib-devel
+        dnf -y install which gcc make openssl-devel openssl g++ zlib-devel libzstd-devel
         make BUILD_TLS=module REDIS_CFLAGS='-Werror'
     - name: testprep
       run: |
@@ -888,7 +915,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror'
+      run: |
+        brew install zstd
+        make REDIS_CFLAGS='-Werror'
     - name: test
       if: true && !contains(github.event.inputs.skiptests, 'redis')
       run: ./runtest --accurate --verbose --clients 1 --no-latency --dump-logs ${{github.event.inputs.test_args}}
@@ -914,7 +943,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror'
+      run: |
+        brew install zstd
+        make REDIS_CFLAGS='-Werror'
     - name: sentinel tests
       if: true && !contains(github.event.inputs.skiptests, 'sentinel')
       run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
@@ -940,7 +971,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror'
+      run: |
+        brew install zstd
+        make REDIS_CFLAGS='-Werror'
     - name: cluster tests
       if: true && !contains(github.event.inputs.skiptests, 'cluster')
       run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
@@ -972,7 +1005,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: |
+        brew install zstd
+        make REDIS_CFLAGS='-Werror -DREDIS_TEST'
 
   test-freebsd:
     runs-on: ubuntu-latest
@@ -1001,7 +1036,7 @@ jobs:
         version: 13.2
         shell: bash
         run: |
-          sudo pkg install -y bash gmake lang/tcl86 lang/tclX gcc
+          sudo pkg install -y bash gmake lang/tcl86 lang/tclX gcc zstd
           gmake
           ./runtest --single unit/keyspace --single unit/auth --single unit/networking --single unit/protocol
 
@@ -1027,7 +1062,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-          apk add build-base zlib-dev
+          apk add build-base zlib-dev zstd-dev
           make REDIS_CFLAGS='-Werror'
     - name: testprep
       run: apk add tcl procps tclx
@@ -1063,7 +1098,7 @@ jobs:
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
       run: |
-          apk add build-base zlib-dev
+          apk add build-base zlib-dev zstd-dev
           make REDIS_CFLAGS='-Werror' USE_JEMALLOC=no CFLAGS=-DUSE_MALLOC_USABLE_SIZE
     - name: testprep
       run: apk add tcl procps tclx
@@ -1098,7 +1133,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DLOG_REQ_RES'
+      run: |
+        sudo apt-get install -y libzstd-dev
+        make REDIS_CFLAGS='-Werror -DLOG_REQ_RES'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx zlib1g-dev
     - name: test
@@ -1147,7 +1184,7 @@ jobs:
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
-        apt-get install -y make gcc-4.8 g++-4.8 zlib1g-dev
+        apt-get install -y make gcc-4.8 g++-4.8 zlib1g-dev libzstd-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
         make CC=gcc REDIS_CFLAGS='-Werror'
@@ -1193,7 +1230,7 @@ jobs:
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
-        apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev zlib1g-dev
+        apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev zlib1g-dev libzstd-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
         make CC=gcc CXX=g++ BUILD_TLS=module REDIS_CFLAGS='-Werror'
@@ -1244,7 +1281,7 @@ jobs:
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
         apt-get update
-        apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev zlib1g-dev
+        apt-get install -y make gcc-4.8 g++-4.8 openssl libssl-dev zlib1g-dev libzstd-dev
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 100
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 100
         make BUILD_TLS=module CC=gcc REDIS_CFLAGS='-Werror'
@@ -1286,7 +1323,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make SANITIZER=address DEBUG_DEFRAG=force REDIS_CFLAGS='-Werror'
+      run: |
+        sudo apt-get install -y libzstd-dev
+        make SANITIZER=address DEBUG_DEFRAG=force REDIS_CFLAGS='-Werror'
     - name: testprep
       run: sudo apt-get install tcl8.6 tclx zlib1g-dev
     - name: test
@@ -1314,7 +1353,9 @@ jobs:
         repository: ${{ env.GITHUB_REPOSITORY }}
         ref: ${{ env.GITHUB_HEAD_REF }}
     - name: make
-      run: make REDIS_CFLAGS='-Werror -DREDIS_TEST'
+      run: |
+        sudo apt-get install -y libzstd-dev
+        make REDIS_CFLAGS='-Werror -DREDIS_TEST'
     - name: testprep
       run: |
         sudo apt-get install tcl8.6 tclx

--- a/redis.conf
+++ b/redis.conf
@@ -839,6 +839,15 @@ replica-priority 100
 # By default min-replicas-to-write is set to 0 (feature disabled) and
 # min-replicas-max-lag is set to 10.
 
+# Enable zlib compression for replication at specified level when connecting to
+# master 0-9 (0 for disabled compression).
+# NOTE: This setting only works when io-threads > 1
+repl-compression 0
+
+# When zlib compression is enabled specify maximum latency in ms before the
+# compressed data is flushed and send to the socket.
+compression-max-latency 100
+
 # A Redis master is able to list the address and port of the attached
 # replicas in different ways. For example the "INFO replication" section
 # offers this information, which is used, among other tools, by

--- a/src/Makefile
+++ b/src/Makefile
@@ -149,7 +149,7 @@ endif
 
 FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
 FINAL_LDFLAGS=$(LDFLAGS) $(OPT) $(REDIS_LDFLAGS) $(DEBUG)
-FINAL_LIBS=-lm -lstdc++
+FINAL_LIBS=-lm -lstdc++ -lz
 DEBUG=-g -ggdb
 
 # Linux ARM32 needs -latomic at linking time
@@ -382,7 +382,7 @@ endif
 
 REDIS_SERVER_NAME=redis-server$(PROG_SUFFIX)
 REDIS_SENTINEL_NAME=redis-sentinel$(PROG_SUFFIX)
-REDIS_SERVER_OBJ=threads_mngr.o memory_prefetch.o adlist.o quicklist.o ae.o anet.o dict.o ebuckets.o eventnotifier.o iothread.o mstr.o entry.o kvstore.o fwtree.o estore.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o cluster_asm.o cluster_legacy.o cluster_slot_stats.o crc16.o endianconv.o slowlog.o eval.o bio.o rio.o rand.o memtest.o syscheck.o crcspeed.o crccombine.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o lolwut8.o acl.o tracking.o socket.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o resp_parser.o call_reply.o script_lua.o script.o functions.o function_lua.o commands.o strl.o connection.o unix.o logreqres.o keymeta.o chk.o hotkeys.o
+REDIS_SERVER_OBJ=threads_mngr.o memory_prefetch.o adlist.o quicklist.o ae.o anet.o dict.o ebuckets.o eventnotifier.o iothread.o mstr.o entry.o kvstore.o fwtree.o estore.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o cluster_asm.o cluster_legacy.o cluster_slot_stats.o crc16.o endianconv.o slowlog.o eval.o bio.o rio.o rand.o memtest.o syscheck.o crcspeed.o crccombine.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o redis-check-rdb.o redis-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o lolwut8.o acl.o tracking.o socket.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o resp_parser.o call_reply.o script_lua.o script.o functions.o function_lua.o commands.o strl.o connection.o unix.o logreqres.o keymeta.o chk.o hotkeys.o client_comp.o
 REDIS_CLI_NAME=redis-cli$(PROG_SUFFIX)
 REDIS_CLI_OBJ=anet.o adlist.o dict.o redis-cli.o zmalloc.o release.o ae.o redisassert.o crcspeed.o crccombine.o crc64.o siphash.o crc16.o monotonic.o cli_common.o mt19937-64.o strl.o cli_commands.o
 REDIS_BENCHMARK_NAME=redis-benchmark$(PROG_SUFFIX)

--- a/src/Makefile
+++ b/src/Makefile
@@ -150,6 +150,18 @@ endif
 FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
 FINAL_LDFLAGS=$(LDFLAGS) $(OPT) $(REDIS_LDFLAGS) $(DEBUG)
 FINAL_LIBS=-lm -lstdc++ -lz
+
+# Detect libzstd via pkg-config, fall back to -lzstd
+LIBZSTD_PKGCONFIG := $(shell $(PKG_CONFIG) --exists libzstd 2>/dev/null && echo $$?)
+ifeq ($(LIBZSTD_PKGCONFIG),0)
+	LIBZSTD_CFLAGS=$(shell $(PKG_CONFIG) --cflags libzstd)
+	LIBZSTD_LIBS=$(shell $(PKG_CONFIG) --libs libzstd)
+else
+	LIBZSTD_CFLAGS=
+	LIBZSTD_LIBS=-lzstd
+endif
+FINAL_CFLAGS+=$(LIBZSTD_CFLAGS)
+FINAL_LIBS+=$(LIBZSTD_LIBS)
 DEBUG=-g -ggdb
 
 # Linux ARM32 needs -latomic at linking time

--- a/src/ae.h
+++ b/src/ae.h
@@ -89,7 +89,7 @@ typedef struct aeEventLoop {
     aeBeforeSleepProc *beforesleep;
     aeBeforeSleepProc *aftersleep;
     int flags;
-    void *privdata[2];
+    void *privdata[3];
 } aeEventLoop;
 
 /* Prototypes */

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -672,6 +672,8 @@ int RedisRegisterConnectionTypeCompression(void) {
 }
 
 int compressionStateCreate(client *c) {
+    UNUSED(zlibType);
+
     compressionState *st = zmalloc(sizeof(compressionState));
     st->type = &zstdType;
     st->last_write = 0;

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -117,7 +117,7 @@ static int connCompressionRead(struct connection *conn, void *buf, size_t buf_le
         int nread = 0;
         /* If the handle_pending flag is raised we only decompress whatever data
          * we have read from the socket without reading anything more. Socket
-         * reading will happend when the event loop handles read event in which
+         * reading will happened when the event loop handles read event in which
          * case the handle_pending flags wouldn't be raised. */
         if (!cc->handle_pending) {
             nread = cc->underlying->type->read(

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -5,6 +5,7 @@
 
 #define ZLIB_TEMP_BUF_SIZE 16 * 1024
 
+/* Abstraction over compression library */
 typedef struct compressionType {
     int (*init_compress)(struct compressionState *st, int level);
     int (*init_decompress)(struct compressionState *st);
@@ -13,6 +14,8 @@ typedef struct compressionType {
     void (*end)(struct compressionState *st);
 } compressionType;
 
+/* Temporary buffer used by compression library to store compressed/decompressed
+ * data. */
 typedef struct {
     unsigned char *data;
     int size;
@@ -30,8 +33,8 @@ struct compressionState {
         ZSTD_CStream *zstdCCtx;  /* Zstd compression ctx */
         ZSTD_DStream *zstdDCtx;  /* Zstd decompression ctx */
     } ctx;
-    int write_flush_pending;    /* zstd: flush not yet completed, keep calling with ZSTD_e_flush */
-    int read_flush_pending;    /* zstd: flush not yet completed, keep calling with ZSTD_e_flush */
+    int write_flush_pending;    /* write flush not yet completed */
+    int read_flush_pending;    /* read flush not yet completed */
     mstime_t last_write;  /* Time since last write. Used to check if it's time
                            * to flush the buffer */
     compressionDirection dir;
@@ -166,12 +169,14 @@ static int zstdInitCompress(compressionState *st, int level) {
         return -1;
     }
 
+    /* temp buf storing compressed data */
     size_t outSize = ZSTD_CStreamOutSize();
     st->output.data = zmalloc(outSize);
     st->output.size = outSize;
     st->output.written = 0;
     st->output.consumed = 0;
 
+    /* temp buf storing uncompressed data */
     size_t inSize = ZSTD_CStreamInSize();
     st->input.data = zmalloc(inSize);
     st->input.size = inSize;
@@ -190,12 +195,14 @@ static int zstdInitDecompress(compressionState *st) {
         return -1;
     }
 
+    /* temp buf storing compressed data */
     size_t inSize = ZSTD_DStreamInSize();
     st->input.data = zmalloc(inSize);
     st->input.size = inSize;
     st->input.written = 0;
     st->input.consumed = 0;
 
+    /* temp buf storing decompressed data */
     size_t outSize = ZSTD_DStreamOutSize();
     st->output.data = zmalloc(outSize);
     st->output.size = outSize;
@@ -222,8 +229,8 @@ static int zstdCompress(compressionState *st, int flush) {
     ZSTD_EndDirective directive;
     /* We use ZSTD_e_end instead of ZSTD_e_flush when we want to flush zstd's.
      * This flushes zstd's internal buffers but also ends the current frame.
-     * This of couse lowers the compression ratio but massively increases speed
-     * on the decompression side also, as it doesnt need to wait for more data.
+     * This of course lowers the compression ratio but massively increases speed
+     * on the decompression side also, as it doesn't need to wait for more data.
      * The resulting compression ratio is still very good (tested with default
      * compression level). */
     if (flush || st->write_flush_pending)
@@ -238,9 +245,9 @@ static int zstdCompress(compressionState *st, int flush) {
             serverLog(LL_WARNING, "zstd compress error: %s", ZSTD_getErrorName(ret));
             return -1;
         }
-    } while (/*directive == ZSTD_e_end && */ret > 0 && output.pos < output.size);
+    } while (ret > 0 && output.pos < output.size);
 
-    /* If we pass a directive differnt than ZSTD_e_continue to zstd we want to
+    /* If we pass a directive different than ZSTD_e_continue to zstd we want to
      * keep using that directive until compressStream2 returns 0. By keeping
      * this flag raised we know we are in the process of flushing data, i.e we
      * cannot use ZSTD_e_continue before we have flushed it all. */
@@ -282,6 +289,7 @@ static int zstdDecompress(compressionState *st) {
 
 static void zstdEnd(compressionState *st) {
     if (st->dir == COMPRESS && st->ctx.zstdCCtx) {
+        /* Flush any pending data so context is in a good state before closing it */
         if (st->write_flush_pending) {
             size_t sz = ZSTD_CStreamOutSize();
             char *tmp = zmalloc(sz);
@@ -317,7 +325,11 @@ static const compressionType zstdType = {
     .end = zstdEnd,
 };
 
-/* Compression connection */
+/* Compression connection. It wraps over existing connection in order to add
+ * compression capability during read/write operations. The `base` member is only
+ * used for getting the ConnectionType but whenever we do any operation on the
+ * connection we use the underlying pointer which is the actual connection.
+ * See CT_Compression. */
 typedef struct compressionConnection {
     connection base;
     connection *underlying;
@@ -399,6 +411,13 @@ static int connCompressionAccept(connection *conn, ConnectionCallbackFunc accept
     return cc->underlying->type->accept(cc->underlying, accept_handler);
 }
 
+/* If decompression is initialized for a connection it reads compressed data
+ * from the underlying connection (i.e usually from socket) into a temp buffer
+ * and decompresses into the passed `buf`. Tries to read and decompress as much
+ * as possible.
+ * There are some scenarios though that we may still have pending data to process
+ * (see clientHasPendingCompressedData). In such cases the connection is added
+ * to the event-loop's pending data and processed via connProcessPendingData. */
 static int connCompressionRead(struct connection *conn, void *buf, size_t buf_len) {
     compressionConnection *cc = (compressionConnection*)conn;
     client *c = connGetPrivateData(conn);
@@ -427,14 +446,6 @@ static int connCompressionRead(struct connection *conn, void *buf, size_t buf_le
                 cc->underlying,
                 state->input.data + state->input.written,
                 state->input.size - state->input.written);
-
-            // if (nread > 0) {
-            //     char *buf = zmalloc(nread + 1);
-            //     memcpy(buf, state->input.data+state->input.written, nread);
-            //     buf[nread] = 0;
-            //     printf("\nNREAD: %s\n", buf);
-            //     zfree(buf);
-            // }
 
             if (nread < 0 && connGetState(cc->underlying) == CONN_STATE_ERROR) {
                 cc->last_read = -1;
@@ -467,6 +478,8 @@ static int connCompressionRead(struct connection *conn, void *buf, size_t buf_le
     return decompressed;
 }
 
+/* Compress all bytes from `data` and pass the compressed data to the underlying's
+ * connection write method. */
 static int connCompressionWrite(connection *conn, const void *data, size_t len) {
     compressionConnection *cc = (compressionConnection*)conn;
     client *c = connGetPrivateData(conn);
@@ -485,14 +498,6 @@ static int connCompressionWrite(connection *conn, const void *data, size_t len) 
 
         memcpy(state->input.data + state->input.written,
                (char*)data + consumed, to_consume);
-
-        // if (to_consume > 0) {
-        //     char *buf = zmalloc(to_consume + 1);
-        //     memcpy(buf, (char*)data+consumed, to_consume);
-        //     buf[to_consume] = 0;
-        //     printf("\nCONSUMED: %s\n", buf);
-        //     zfree(buf);
-        // }
 
         state->input.written += to_consume;
         consumed += to_consume;
@@ -637,6 +642,11 @@ static int compressionHasPendingData(struct aeEventLoop *el) {
     return listLength(pending_list) > 0;
 }
 
+/* Handling pending data involves calling the read handler of the underlying
+ * connection. We don't actually want to call connRead on it as we handle only
+ * pending data(i.e internal buffers of the compression library not yet flushed
+ * or non-consumed decompressed data in our temp buffers) and not any actual
+ * read events. */
 static int compressionProcessPendingData(struct aeEventLoop *el) {
     list *pending_list = el->privdata[2];
     if (!pending_list || listLength(pending_list) == 0)
@@ -659,7 +669,7 @@ static int compressionProcessPendingData(struct aeEventLoop *el) {
     return processed;
 }
 
-/* Compression connection */
+/* ConnectionType for the compression connection */
 static ConnectionType CT_Compression = {
     /* connection type */
     .get_type = connCompressionGetType,
@@ -719,6 +729,7 @@ int RedisRegisterConnectionTypeCompression(void) {
     return connTypeRegister(&CT_Compression);
 }
 
+/* Create compression state for the client */
 int compressionStateCreate(client *c) {
     UNUSED(zlibType);
 
@@ -743,6 +754,10 @@ void compressionStateDestroy(compressionState *state) {
     zfree(state);
 }
 
+/* Create and initialize a compression state for the client. No-op if already
+ * initialized. `dir` indicates the compression direction, i.e if the client
+ * will compress or decompress data.
+ * Currently only viable for master/replica clients. */
 int clientCreateCompressionState(client *c, compressionDirection dir) {
     /* Client compression already initialized */
     if (c->compression_state != NULL)
@@ -795,6 +810,8 @@ int clientCreateCompressionState(client *c, compressionDirection dir) {
 void clientDestroyCompressionState(client *c) {
     if (c->compression_state == NULL) return;
 
+    /* If the connection is not destroyed yet we need to switch back to the
+     * underlying connection. */
     if (c->conn) {
         compressionConnection *cc = (compressionConnection*)c->conn;
         c->conn = cc->underlying;
@@ -818,6 +835,7 @@ void clientDestroyCompressionState(client *c) {
  * Return 0 if compression state was not created and failed to be initialized,
  * 1 if compression was enabled. */
 int clientEnableCompression(client *c, compressionDirection dir) {
+    serverAssert((c->flags & CLIENT_MASTER) || (c->flags & CLIENT_SLAVE));
     if (!clientCreateCompressionState(c, dir)) {
         return 0;
     }
@@ -826,15 +844,14 @@ int clientEnableCompression(client *c, compressionDirection dir) {
     return 1;
 }
 
-/* Disable compression without destroying compression state. If compression was
- * not initialized does nothing. */
+/* Disable compression without destroying compression state. */
 void clientDisableCompression(client *c) {
     c->io_flags &= ~CLIENT_IO_COMPRESSION_ENABLED;
 }
 
 /* Compress any data send for compression (see connCompressionWrite) and
- * write to socket. Zlib may not return compressed data immediately so this
- * call may not write anything to socket.
+ * write to socket. Compression library may not return compressed data
+ * immediately so this call may not write anything to socket.
  * Force flushes the compressed buffer according to compression_max_latency.
  * Return number of bytes written to socket or -1 on socket write error. */
 int compressAndWrite(client *c, int *tot_written) {
@@ -858,7 +875,6 @@ int compressAndWrite(client *c, int *tot_written) {
          * Note, this only makes sense when we have enough space for compressing
          * data. */
         int flush = mstime() - state->last_write > server.compression_max_latency;
-        // if (flush) serverLog(LL_NOTICE, "Flushing client %llu", c->id);
         if (state->type->compress(state, flush) == -1) {
             clientDestroyCompressionState(c);
             return 1;
@@ -877,14 +893,6 @@ int compressAndWrite(client *c, int *tot_written) {
         if (written < 0) {
             return 1;
         }
-
-        // if (written > 0) {
-        //     char *buf = zmalloc(written + 1);
-        //     memcpy(buf, state->output.data+state->output.consumed, written);
-        //     buf[written] = 0;
-        //     printf("WRITTEN COMPRESSED: %s\n", buf);
-        //     zfree(buf);
-        // }
 
         state->output.consumed += written;
         *tot_written += written;
@@ -906,6 +914,10 @@ int compressAndWrite(client *c, int *tot_written) {
     return 0;
 }
 
+/* Decompress input compressed data and put it in `buf`. If decompressed data
+ * is more than buflen this function must be called again so output data can
+ * be consumed. If buflen is sufficiently large this function will decompress
+ * as much data as possible. */
 int decompressInto(compressionState *state, char *buf, size_t buflen) {
     if (buflen == 0)
       return 0;
@@ -937,14 +949,6 @@ int decompressInto(compressionState *state, char *buf, size_t buflen) {
             size_t nonconsumed_decompressed = state->output.written - state->output.consumed;
             int to_consume = min(buflen - consumed, nonconsumed_decompressed);
             memcpy(buf + consumed, state->output.data + state->output.consumed, to_consume);
-
-            // if (to_consume > 0) {
-            //     char *res = zmalloc(to_consume + 1);
-            //     memcpy(res, buf+consumed, to_consume);
-            //     res[to_consume] = 0;
-            //     printf("\nDECOMPRESSED: %s\n", res);
-            //     zfree(res);
-            // }
 
             state->output.consumed += to_consume;
             consumed += to_consume;
@@ -993,14 +997,6 @@ int readFromBufAndDecompress(client *c, char *input_buf, size_t input_len,
             memcpy(state->input.data + state->input.written,
                    input_buf + *consumed, to_consume);
 
-        // if (to_consume > 0) {
-        //     char *buf = zmalloc(to_consume + 1);
-        //     memcpy(buf, state->input.data+state->input.written, to_consume);
-        //     buf[to_consume] = 0;
-        //     printf("\nNREAD: %s\n", buf);
-        //     zfree(buf);
-        // }
-
         *consumed += to_consume;
 
         state->input.written += to_consume;
@@ -1015,6 +1011,10 @@ int readFromBufAndDecompress(client *c, char *input_buf, size_t input_len,
     return tot_decompressed;
 }
 
+/* Check if we need to flush compressed data. Compression library may wait for
+ * a lot of compressed data before it finishes a frame and gives it back to user.
+ * While this gives the best compression ratio it introduces a lot of latency so
+ * we make a compromise and flush periodically. */
 int clientHasPendingCompressionFlush(client *c) {
     compressionState *state = c->compression_state;
     if (!state) return 0;
@@ -1023,6 +1023,10 @@ int clientHasPendingCompressionFlush(client *c) {
     return state->write_flush_pending || (mstime() - state->last_write >= server.compression_max_latency);
 }
 
+/* Check if we still have pending compressed data. This may mean that either the
+ * compression library still has data in it's internal buffers, we still have
+ * compressed data that needs to be consumed by the library or we have stored
+ * decompressed data that we still have not consumed. */
 int clientHasPendingCompressedData(client *c) {
     compressionState *state = c->compression_state;
     if (!state) return 0;

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -2,6 +2,7 @@
 #include "client_comp.h"
 #include <zlib.h>
 
+/* Main compression state struct */
 #define ZLIB_TEMP_BUF_SIZE 16 * 1024
 
 typedef struct {
@@ -16,9 +17,283 @@ struct compressionState {
     z_stream zlib;        /* Zlib state */
     mstime_t last_write;  /* Time since last write. Used to check if it's time
                            * to flush the buffer */
-    int inflate_inited;
-    int deflate_inited;
+    compressionDirection dir;
 };
+
+/* Compression connection */
+typedef struct compressionConnection {
+    connection base;
+    connection *underlying;
+    listNode *pending_list_node;
+    size_t last_read;
+    int handle_pending;
+} compressionConnection;
+
+int decompressInto(compressionState *state, char *buf, size_t buflen);
+
+int connCompressionRead(struct connection *conn, void *buf, size_t buf_len) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    client *c = connGetPrivateData(conn);
+    compressionState *state = c->compression_state;
+    if (!state || state->dir != DECOMPRESS)
+        return connRead(cc->underlying, buf, buf_len);
+
+    cc->last_read = 0;
+    size_t decompressed = 0;
+    do {
+        int curr = decompressInto(state, (char*)buf + decompressed, buf_len - decompressed);
+        /* Decompression error, we should close the connection */
+        if (curr < 0) {
+            cc->underlying->state = CONN_STATE_CLOSED;
+            break;
+        }
+        decompressed += curr;
+
+        int nread = 0;
+        if (!cc->handle_pending) {
+            nread = cc->underlying->type->read(
+                cc->underlying,
+                state->compressed.data + state->compressed.used,
+                ZLIB_TEMP_BUF_SIZE - state->compressed.used);
+
+            if (nread > 0) {
+                char *buf = zmalloc(nread + 1);
+                memcpy(buf, state->compressed.data+state->compressed.used, nread);
+                buf[nread] = 0;
+                printf("\nNREAD: %s\n", buf);
+                zfree(buf);
+            }
+
+            if (nread < 0 && connGetState(cc->underlying) == CONN_STATE_ERROR) {
+                cc->last_read = -1;
+                return -1;
+            }
+            /* Even if nread == 0 we continue the loop until decompressInto has
+             * nothing more it can do. */
+            if (nread > 0) {
+                cc->last_read += nread;
+                state->compressed.used += nread;
+                state->zlib.avail_in += nread;
+            }
+        }
+
+        if (curr <= 0 && nread <= 0) break;
+    } while (decompressed <= buf_len);
+
+    if (decompressed == 0 && connGetState(cc->underlying) == CONN_STATE_CONNECTED)
+        return -1;
+
+    return decompressed;
+}
+
+static const char *connCompressionGetType(connection *conn) {
+    UNUSED(conn);
+    return CONN_TYPE_COMPRESSION;
+}
+
+static void connCompressionAeHandler(aeEventLoop *el, int fd, void *clientData, int mask) {
+    compressionConnection *cc = (compressionConnection *)clientData;
+    cc->underlying->type->ae_handler(el, fd, clientData, mask);
+}
+
+static int connCompressionAddr(connection *conn, char *ip, size_t ip_len, int *port, int remote) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->addr(cc->underlying, ip, ip_len, port, remote);
+}
+
+static int connCompressionIsLocal(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->is_local(cc->underlying);
+}
+
+static void connCompressionShutdown(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    cc->underlying->type->shutdown(cc->underlying);
+}
+
+static void connCompressionClose(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    if (cc->pending_list_node) {
+        list *l = cc->underlying->el->privdata[2];
+        if (l) listDelNode(l, cc->pending_list_node);
+    }
+    cc->underlying->type->close(cc->underlying);
+    zfree(conn);
+}
+
+static int connCompressionConnect(connection *conn, const char *addr, int port, const char *source_addr, ConnectionCallbackFunc connect_handler) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->connect(cc->underlying, addr, port, source_addr, connect_handler);
+}
+
+static int connCompressionBlockingConnect(connection *conn, const char *addr, int port, long long timeout) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->blocking_connect(cc->underlying, addr, port, timeout);
+}
+
+static int connCompressionAccept(connection *conn, ConnectionCallbackFunc accept_handler) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->accept(cc->underlying, accept_handler);
+}
+
+static int connCompressionWrite(connection *conn, const void *data, size_t data_len) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->write(cc->underlying, data, data_len);
+}
+
+static int connCompressionWritev(connection *conn, const struct iovec *iov, int iovcnt) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->writev(cc->underlying, iov, iovcnt);
+}
+
+static int connCompressionSetWriteHandler(connection *conn, ConnectionCallbackFunc handler, int barrier) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->set_write_handler(cc->underlying, handler, barrier);
+}
+
+static int connCompressionSetReadHandler(connection *conn, ConnectionCallbackFunc handler) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->set_read_handler(cc->underlying, handler);
+}
+
+static const char *connCompressionGetLastError(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->get_last_error(cc->underlying);
+}
+
+static ssize_t connCompressionSyncWrite(connection *conn, char *ptr, ssize_t size, long long timeout) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->sync_write(cc->underlying, ptr, size, timeout);
+}
+
+static ssize_t connCompressionSyncRead(connection *conn, char *ptr, ssize_t size, long long timeout) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->sync_read(cc->underlying, ptr, size, timeout);
+}
+
+static ssize_t connCompressionSyncReadLine(connection *conn, char *ptr, ssize_t size, long long timeout) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->sync_readline(cc->underlying, ptr, size, timeout);
+}
+
+static size_t connCompressionGetLastRead(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->last_read;
+}
+
+static int connCompressionRebindEventLoop(connection *conn, aeEventLoop *el) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->type->rebind_event_loop(cc->underlying, el);
+}
+
+static aeEventLoop *connCompressionGetEventLoop(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->el;
+}
+
+static void connCompressionUnsetEventLoop(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    cc->underlying->el = NULL;
+}
+
+static int connCompressionGetFd(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->fd;
+}
+
+static int connCompressionGetIovcnt(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->iovcnt;
+}
+
+static int connCompressionGetState(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->state;
+}
+
+static int connCompressionGetLastErrno(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->last_errno;
+}
+
+static int connCompressionHasReadHandler(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->read_handler != NULL;
+}
+
+static int connCompressionHasWriteHandler(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->write_handler != NULL;
+}
+
+static void connCompressionSetPrivateData(connection *conn, void *data) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    cc->underlying->private_data = data;
+}
+
+static void *connCompressionGetPrivateData(connection *conn) {
+    compressionConnection *cc = (compressionConnection *)conn;
+    return cc->underlying->private_data;
+}
+
+/* Compression connection */
+static ConnectionType CT_Compression = {
+    /* connection type */
+    .get_type = connCompressionGetType,
+
+    /* ae & accept & listen & error & address handler */
+    .ae_handler = connCompressionAeHandler,
+    .addr = connCompressionAddr,
+    .is_local = connCompressionIsLocal,
+
+    /* shutdown/close connection */
+    .shutdown = connCompressionShutdown,
+    .close = connCompressionClose,
+
+    /* connect & accept */
+    .connect = connCompressionConnect,
+    .blocking_connect = connCompressionBlockingConnect,
+    .accept = connCompressionAccept,
+
+    /* event loop */
+    .unbind_event_loop = NULL,
+    .rebind_event_loop = connCompressionRebindEventLoop,
+
+    /* IO */
+    .read = connCompressionRead,
+    .write = connCompressionWrite,
+    .writev = connCompressionWritev,
+    .set_write_handler = connCompressionSetWriteHandler,
+    .set_read_handler = connCompressionSetReadHandler,
+    .get_last_error = connCompressionGetLastError,
+    .sync_write = connCompressionSyncWrite,
+    .sync_read = connCompressionSyncRead,
+    .sync_readline = connCompressionSyncReadLine,
+    .get_last_read = connCompressionGetLastRead,
+
+    /* pending data */
+    .has_pending_data = NULL,
+    .process_pending_data = NULL,
+
+    .get_peer_cert = NULL,
+    .get_peer_username = NULL,
+
+    /* connection accessors */
+    .get_event_loop = connCompressionGetEventLoop,
+    .unset_event_loop = connCompressionUnsetEventLoop,
+    .get_fd = connCompressionGetFd,
+    .get_iovcnt = connCompressionGetIovcnt,
+    .get_state = connCompressionGetState,
+    .get_last_errno = connCompressionGetLastErrno,
+    .has_read_handler = connCompressionHasReadHandler,
+    .has_write_handler = connCompressionHasWriteHandler,
+    .set_private_data = connCompressionSetPrivateData,
+    .get_private_data = connCompressionGetPrivateData,
+};
+
+int RedisRegisterConnectionTypeCompression(void) {
+    return connTypeRegister(&CT_Compression);
+}
 
 static void *zlib_alloc_wrapper(void *opaque, unsigned int items,
                                 unsigned int size) {
@@ -39,7 +314,7 @@ int compressionStateCreate(client *c) {
     st->zlib.zfree = zlib_free_wrapper;
 
     st->last_write = 0;
-    st->inflate_inited = st->deflate_inited = 0;
+    st->dir = CD_INVALID;
 
     c->compression_state = st;
 
@@ -50,10 +325,10 @@ int compressionStateCreate(client *c) {
 void compressionStateDestroy(compressionState *state) {
     if (state == NULL) return;
 
-    if (state->inflate_inited) {
+    if (state->dir == DECOMPRESS) {
         inflateEnd(&state->zlib);
     }
-    if (state->deflate_inited) {
+    if (state->dir == COMPRESS) {
         deflateEnd(&state->zlib);
     }
 
@@ -86,7 +361,7 @@ int clientCreateCompressionState(client *c, compressionDirection dir) {
         st->zlib.next_in = st->uncompressed.data;
         st->uncompressed.used = 0;
 
-        st->deflate_inited = 1;
+        st->dir = COMPRESS;
 
         serverLog(LL_NOTICE, "Initialized compression at level %d for client #%llu...",
                 c->compression_level, (unsigned long long)c->id);
@@ -107,7 +382,16 @@ int clientCreateCompressionState(client *c, compressionDirection dir) {
         st->zlib.next_in = st->compressed.data;
         st->uncompressed.used = 0;
 
-        st->inflate_inited = 1;
+        st->dir = DECOMPRESS;
+
+        compressionConnection *cc = zmalloc(sizeof(compressionConnection));
+        cc->base.type = &CT_Compression;
+        cc->underlying = c->conn;
+        cc->pending_list_node = NULL;
+        cc->last_read = 0;
+        cc->handle_pending = 0;
+
+        c->conn = (connection*)cc;
 
         serverLog(LL_NOTICE, "Decompression for master client initialized.");
     } else {
@@ -119,6 +403,17 @@ int clientCreateCompressionState(client *c, compressionDirection dir) {
 
 void clientDestroyCompressionState(client *c) {
     if (c->compression_state == NULL) return;
+
+    if (c->compression_state->dir == DECOMPRESS && c->conn) {
+        compressionConnection *cc = (compressionConnection*)c->conn;
+        c->conn = cc->underlying;
+
+        if (cc->pending_list_node) {
+            list *l = cc->base.el ? cc->base.el->privdata[2] : NULL;
+            if (l) listDelNode(l, cc->pending_list_node);
+        }
+        zfree(cc);
+    }
 
     compressionStateDestroy(c->compression_state);
     c->compression_state = NULL;
@@ -202,6 +497,7 @@ int compressAndWrite(client *c) {
         //     memcpy(buf, state->compressed.data+state->compressed.used, written);
         //     buf[written] = 0;
         //     printf("\nWRITTEN: %s\n", buf);
+        //     zfree(buf);
         // }
 
         if (written > 0) {
@@ -282,12 +578,9 @@ int consumeAndTryWriteCompressed(client *c, const char *data, size_t len,
     return consumed;
 }
 
-int decompressInto(client *c, char *buf, size_t buflen) {
+int decompressInto(compressionState *state, char *buf, size_t buflen) {
     if (buflen == 0)
       return 0;
-
-    compressionState *state = c->compression_state;
-    serverAssert(state);
 
     int consumed = 0;
 
@@ -309,8 +602,6 @@ int decompressInto(client *c, char *buf, size_t buflen) {
             int err = inflate(&state->zlib, Z_SYNC_FLUSH);
             if (err != Z_OK && err != Z_BUF_ERROR) {
                 serverLog(LL_NOTICE, "Decompress error: %s (%d)", state->zlib.msg, err);
-                clientDestroyCompressionState(c);
-                freeClientAsync(c);
                 return -1;
             }
         }
@@ -376,7 +667,7 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *net_re
     }
 
     /* Try to read any available decompressed data */
-    int written = decompressInto(c, buf, buflen);
+    int written = decompressInto(state, buf, buflen);
     if (written == -1) {
         return -1;
     }
@@ -418,7 +709,7 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *net_re
             *net_read += nread;
         }
 
-        int decompressed = decompressInto(c, buf + tot_decompressed,
+        int decompressed = decompressInto(state, buf + tot_decompressed,
                                           buflen - tot_decompressed);
         if (decompressed <= 0)
             break;
@@ -445,20 +736,29 @@ int readFromBufAndDecompress(client *c, char *input_buf, size_t input_len,
 
     int tot_decompressed = 0;
     *consumed = 0;
-    while (*consumed < input_len && (size_t)tot_decompressed < output_len) {
+    while (*consumed <= input_len && (size_t)tot_decompressed < output_len) {
         int to_consume =
             min(ZLIB_TEMP_BUF_SIZE - state->compressed.used,
                 (int)(input_len - *consumed));
 
-        memcpy(state->compressed.data + state->compressed.used,
-               input_buf + *consumed, to_consume);
+        if (to_consume)
+            memcpy(state->compressed.data + state->compressed.used,
+                   input_buf + *consumed, to_consume);
+
+        // if (to_consume > 0) {
+        //     char *buf = zmalloc(to_consume + 1);
+        //     memcpy(buf, state->compressed.data+state->compressed.used, to_consume);
+        //     buf[to_consume] = 0;
+        //     printf("\nNREAD: %s\n", buf);
+        //     zfree(buf);
+        // }
 
         *consumed += to_consume;
 
         state->compressed.used += to_consume;
         state->zlib.avail_in += to_consume;
 
-        int decompressed = decompressInto(c, output_buf + tot_decompressed,
+        int decompressed = decompressInto(state, output_buf + tot_decompressed,
                                           output_len - tot_decompressed);
         if (decompressed <= 0)
             break;
@@ -466,13 +766,12 @@ int readFromBufAndDecompress(client *c, char *input_buf, size_t input_len,
     }
 
     return tot_decompressed;
-
 }
 
 int clientHasPendingCompressionFlush(client *c) {
     compressionState *state = c->compression_state;
     if (!state) return 0;
-    if (!state->deflate_inited) return 0;
+    if (state->dir != COMPRESS) return 0;
 
     // return state->zlib.avail_out > 0 || (state->zlib.next_out - (state->compressed.data + state->compressed.used) > 0);
     return mstime() - state->last_write >= server.compression_max_latency;
@@ -481,9 +780,20 @@ int clientHasPendingCompressionFlush(client *c) {
 int clientHasPendingCompressedData(client *c) {
     compressionState *state = c->compression_state;
     if (!state) return 0;
-    if (!state->inflate_inited) return 0;
+    if (state->dir != DECOMPRESS) return 0;
 
-    return state->zlib.avail_in > 0 ||
+    return state->zlib.avail_in > 0 &&
            state->zlib.next_out > state->uncompressed.data + state->uncompressed.used;
 }
 
+int clientProcessPendingCompressedData(struct client *c) {
+    if (!connHasReadHandler(c->conn)) return 0;
+    if (!clientHasPendingCompressedData(c)) return 0;
+
+    compressionConnection *cc = (compressionConnection*)c->conn;
+    cc->handle_pending = 1;
+    cc->underlying->read_handler(cc->underlying);
+    cc->handle_pending = 0;
+
+    return 1;
+}

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -24,14 +24,79 @@ struct compressionState {
 typedef struct compressionConnection {
     connection base;
     connection *underlying;
-    listNode *pending_list_node;
+    listNode *pending_data_node;
     size_t last_read;
+    size_t last_written;
     int handle_pending;
 } compressionConnection;
 
 int decompressInto(compressionState *state, char *buf, size_t buflen);
 
-int connCompressionRead(struct connection *conn, void *buf, size_t buf_len) {
+static void compressionPendingAdd(compressionConnection *cc) {
+    if (cc->pending_data_node) return;
+
+    if (!cc->underlying->el->privdata[2])
+        cc->underlying->el->privdata[2] = listCreate();
+
+    list *l = cc->underlying->el->privdata[2];
+    listAddNodeTail(l, cc);
+    cc->pending_data_node = listLast(l);
+}
+
+static void compressionPendingRemove(compressionConnection *cc) {
+    list *l = cc->underlying->el->privdata[2];
+    if (!l || listLength(l) == 0) return;
+    listDelNode(l, cc->pending_data_node);
+    cc->pending_data_node = NULL;
+}
+
+static const char *connCompressionGetType(connection *conn) {
+    UNUSED(conn);
+    return CONN_TYPE_COMPRESSION;
+}
+
+static void connCompressionAeHandler(aeEventLoop *el, int fd, void *clientData, int mask) {
+    compressionConnection *cc = (compressionConnection *)clientData;
+    cc->underlying->type->ae_handler(el, fd, clientData, mask);
+}
+
+static int connCompressionAddr(connection *conn, char *ip, size_t ip_len, int *port, int remote) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    return cc->underlying->type->addr(cc->underlying, ip, ip_len, port, remote);
+}
+
+static int connCompressionIsLocal(connection *conn) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    return cc->underlying->type->is_local(cc->underlying);
+}
+
+static void connCompressionShutdown(connection *conn) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    cc->underlying->type->shutdown(cc->underlying);
+}
+
+static void connCompressionClose(connection *conn) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    cc->underlying->type->close(cc->underlying);
+    zfree(conn);
+}
+
+static int connCompressionConnect(connection *conn, const char *addr, int port, const char *source_addr, ConnectionCallbackFunc connect_handler) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    return cc->underlying->type->connect(cc->underlying, addr, port, source_addr, connect_handler);
+}
+
+static int connCompressionBlockingConnect(connection *conn, const char *addr, int port, long long timeout) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    return cc->underlying->type->blocking_connect(cc->underlying, addr, port, timeout);
+}
+
+static int connCompressionAccept(connection *conn, ConnectionCallbackFunc accept_handler) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    return cc->underlying->type->accept(cc->underlying, accept_handler);
+}
+
+static int connCompressionRead(struct connection *conn, void *buf, size_t buf_len) {
     compressionConnection *cc = (compressionConnection*)conn;
     client *c = connGetPrivateData(conn);
     compressionState *state = c->compression_state;
@@ -50,19 +115,23 @@ int connCompressionRead(struct connection *conn, void *buf, size_t buf_len) {
         decompressed += curr;
 
         int nread = 0;
+        /* If the handle_pending flag is raised we only decompress whatever data
+         * we have read from the socket without reading anything more. Socket
+         * reading will happend when the event loop handles read event in which
+         * case the handle_pending flags wouldn't be raised. */
         if (!cc->handle_pending) {
             nread = cc->underlying->type->read(
                 cc->underlying,
                 state->compressed.data + state->compressed.used,
                 ZLIB_TEMP_BUF_SIZE - state->compressed.used);
 
-            if (nread > 0) {
-                char *buf = zmalloc(nread + 1);
-                memcpy(buf, state->compressed.data+state->compressed.used, nread);
-                buf[nread] = 0;
-                printf("\nNREAD: %s\n", buf);
-                zfree(buf);
-            }
+            // if (nread > 0) {
+            //     char *buf = zmalloc(nread + 1);
+            //     memcpy(buf, state->compressed.data+state->compressed.used, nread);
+            //     buf[nread] = 0;
+            //     printf("\nNREAD: %s\n", buf);
+            //     zfree(buf);
+            // }
 
             if (nread < 0 && connGetState(cc->underlying) == CONN_STATE_ERROR) {
                 cc->last_read = -1;
@@ -83,157 +152,204 @@ int connCompressionRead(struct connection *conn, void *buf, size_t buf_len) {
     if (decompressed == 0 && connGetState(cc->underlying) == CONN_STATE_CONNECTED)
         return -1;
 
+    if (clientHasPendingCompressedData(c)) {
+        compressionPendingAdd(cc);
+    } else {
+        compressionPendingRemove(cc);
+    }
+
     return decompressed;
 }
 
-static const char *connCompressionGetType(connection *conn) {
-    UNUSED(conn);
-    return CONN_TYPE_COMPRESSION;
-}
+static int connCompressionWrite(connection *conn, const void *data, size_t len) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    client *c = connGetPrivateData(conn);
+    compressionState *state = c->compression_state;
+    /* If no compression state or we are not compressing data - defer to
+     * underlying connection. */
+    if (!state || state->dir != COMPRESS)
+        return connWrite(cc->underlying, data, len);
 
-static void connCompressionAeHandler(aeEventLoop *el, int fd, void *clientData, int mask) {
-    compressionConnection *cc = (compressionConnection *)clientData;
-    cc->underlying->type->ae_handler(el, fd, clientData, mask);
-}
+    int consumed = 0;
+    cc->last_written = 0;
+    while ((size_t)consumed != len) {
+        int to_consume =
+            min(ZLIB_TEMP_BUF_SIZE - state->uncompressed.used, (int)(len - consumed));
+        serverAssert(to_consume >= 0);
 
-static int connCompressionAddr(connection *conn, char *ip, size_t ip_len, int *port, int remote) {
-    compressionConnection *cc = (compressionConnection *)conn;
-    return cc->underlying->type->addr(cc->underlying, ip, ip_len, port, remote);
-}
+        memcpy(state->uncompressed.data + state->uncompressed.used,
+               (char*)data + consumed, to_consume);
 
-static int connCompressionIsLocal(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
-    return cc->underlying->type->is_local(cc->underlying);
-}
+        // if (to_consume > 0) {
+        //     char *buf = zmalloc(to_consume + 1);
+        //     memcpy(buf, data+consumed, to_consume);
+        //     buf[to_consume] = 0;
+        //     printf("\nCONSUMED: %s\n", buf);
+        // }
 
-static void connCompressionShutdown(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
-    cc->underlying->type->shutdown(cc->underlying);
-}
+        state->uncompressed.used += to_consume;
+        consumed += to_consume;
+        state->zlib.avail_in += to_consume;
 
-static void connCompressionClose(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
-    if (cc->pending_list_node) {
-        list *l = cc->underlying->el->privdata[2];
-        if (l) listDelNode(l, cc->pending_list_node);
+        /* Write whatever we have available in the compressed buffer */
+        int written = 0;
+        int err = compressAndWrite(c, &written);
+        cc->last_written += written;
+        if (err) {
+            if (connGetState(c->conn) != CONN_STATE_CONNECTED) {
+                return -1;
+            }
+            return consumed;
+        }
+
+        if (written == 0)
+            break;
     }
-    cc->underlying->type->close(cc->underlying);
-    zfree(conn);
-}
 
-static int connCompressionConnect(connection *conn, const char *addr, int port, const char *source_addr, ConnectionCallbackFunc connect_handler) {
-    compressionConnection *cc = (compressionConnection *)conn;
-    return cc->underlying->type->connect(cc->underlying, addr, port, source_addr, connect_handler);
-}
-
-static int connCompressionBlockingConnect(connection *conn, const char *addr, int port, long long timeout) {
-    compressionConnection *cc = (compressionConnection *)conn;
-    return cc->underlying->type->blocking_connect(cc->underlying, addr, port, timeout);
-}
-
-static int connCompressionAccept(connection *conn, ConnectionCallbackFunc accept_handler) {
-    compressionConnection *cc = (compressionConnection *)conn;
-    return cc->underlying->type->accept(cc->underlying, accept_handler);
-}
-
-static int connCompressionWrite(connection *conn, const void *data, size_t data_len) {
-    compressionConnection *cc = (compressionConnection *)conn;
-    return cc->underlying->type->write(cc->underlying, data, data_len);
+    return consumed;
 }
 
 static int connCompressionWritev(connection *conn, const struct iovec *iov, int iovcnt) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->type->writev(cc->underlying, iov, iovcnt);
 }
 
 static int connCompressionSetWriteHandler(connection *conn, ConnectionCallbackFunc handler, int barrier) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->type->set_write_handler(cc->underlying, handler, barrier);
 }
 
 static int connCompressionSetReadHandler(connection *conn, ConnectionCallbackFunc handler) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->type->set_read_handler(cc->underlying, handler);
 }
 
 static const char *connCompressionGetLastError(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->type->get_last_error(cc->underlying);
 }
 
 static ssize_t connCompressionSyncWrite(connection *conn, char *ptr, ssize_t size, long long timeout) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->type->sync_write(cc->underlying, ptr, size, timeout);
 }
 
 static ssize_t connCompressionSyncRead(connection *conn, char *ptr, ssize_t size, long long timeout) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->type->sync_read(cc->underlying, ptr, size, timeout);
 }
 
 static ssize_t connCompressionSyncReadLine(connection *conn, char *ptr, ssize_t size, long long timeout) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->type->sync_readline(cc->underlying, ptr, size, timeout);
 }
 
 static size_t connCompressionGetLastRead(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->last_read;
 }
 
+static size_t connCompressionGetLastWritten(connection *conn) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    return cc->last_written;
+}
+
+static void connCompressionUnbindEventLoop(connection *conn) {
+    compressionConnection *cc = (compressionConnection*)conn;
+    aeEventLoop *el = cc->underlying->el;
+    if (el) {
+        int fd = cc->underlying->fd;
+        int mask = aeGetFileEvents(el, cc->underlying->fd);
+        if (mask & AE_READABLE) aeDeleteFileEvent(el, fd, AE_READABLE);
+        if (mask & AE_WRITABLE) aeDeleteFileEvent(el, fd, AE_WRITABLE);
+    }
+    if (cc->pending_data_node) {
+        compressionPendingRemove(cc);
+    }
+}
+
 static int connCompressionRebindEventLoop(connection *conn, aeEventLoop *el) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->type->rebind_event_loop(cc->underlying, el);
 }
 
 static aeEventLoop *connCompressionGetEventLoop(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->el;
 }
 
 static void connCompressionUnsetEventLoop(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     cc->underlying->el = NULL;
 }
 
 static int connCompressionGetFd(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->fd;
 }
 
 static int connCompressionGetIovcnt(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->iovcnt;
 }
 
 static int connCompressionGetState(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->state;
 }
 
 static int connCompressionGetLastErrno(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->last_errno;
 }
 
 static int connCompressionHasReadHandler(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->read_handler != NULL;
 }
 
 static int connCompressionHasWriteHandler(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->write_handler != NULL;
 }
 
 static void connCompressionSetPrivateData(connection *conn, void *data) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     cc->underlying->private_data = data;
 }
 
 static void *connCompressionGetPrivateData(connection *conn) {
-    compressionConnection *cc = (compressionConnection *)conn;
+    compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->private_data;
+}
+
+static int compressionHasPendingData(struct aeEventLoop *el) {
+    list *pending_list = el->privdata[2];
+    if (!pending_list)
+        return 0;
+    return listLength(pending_list) > 0;
+}
+
+static int compressionProcessPendingData(struct aeEventLoop *el) {
+    list *pending_list = el->privdata[2];
+    if (!pending_list || listLength(pending_list) == 0)
+        return 0;
+
+    listIter li;
+    listNode *ln;
+    int processed = 0;
+    listRewind(pending_list,&li);
+    while((ln = listNext(&li))) {
+        compressionConnection *cc = listNodeValue(ln);
+        if (!connHasReadHandler((connection*)cc)) continue;
+
+        cc->handle_pending = 1;
+        cc->underlying->read_handler(cc->underlying);
+        cc->handle_pending = 0;
+
+        ++processed;
+    }
+    return processed;
 }
 
 /* Compression connection */
@@ -256,7 +372,7 @@ static ConnectionType CT_Compression = {
     .accept = connCompressionAccept,
 
     /* event loop */
-    .unbind_event_loop = NULL,
+    .unbind_event_loop = connCompressionUnbindEventLoop,
     .rebind_event_loop = connCompressionRebindEventLoop,
 
     /* IO */
@@ -270,10 +386,11 @@ static ConnectionType CT_Compression = {
     .sync_read = connCompressionSyncRead,
     .sync_readline = connCompressionSyncReadLine,
     .get_last_read = connCompressionGetLastRead,
+    .get_last_written = connCompressionGetLastWritten,
 
     /* pending data */
-    .has_pending_data = NULL,
-    .process_pending_data = NULL,
+    .has_pending_data = compressionHasPendingData,
+    .process_pending_data = compressionProcessPendingData,
 
     .get_peer_cert = NULL,
     .get_peer_username = NULL,
@@ -384,19 +501,19 @@ int clientCreateCompressionState(client *c, compressionDirection dir) {
 
         st->dir = DECOMPRESS;
 
-        compressionConnection *cc = zmalloc(sizeof(compressionConnection));
-        cc->base.type = &CT_Compression;
-        cc->underlying = c->conn;
-        cc->pending_list_node = NULL;
-        cc->last_read = 0;
-        cc->handle_pending = 0;
-
-        c->conn = (connection*)cc;
-
         serverLog(LL_NOTICE, "Decompression for master client initialized.");
     } else {
         serverAssert(0);
     }
+
+    compressionConnection *cc = zmalloc(sizeof(compressionConnection));
+    cc->base.type = &CT_Compression;
+    cc->underlying = c->conn;
+    cc->pending_data_node = NULL;
+    cc->last_read = 0;
+    cc->last_written = 0;
+    cc->handle_pending = 0;
+    c->conn = (connection*)cc;
 
     return 1;
 }
@@ -408,10 +525,6 @@ void clientDestroyCompressionState(client *c) {
         compressionConnection *cc = (compressionConnection*)c->conn;
         c->conn = cc->underlying;
 
-        if (cc->pending_list_node) {
-            list *l = cc->base.el ? cc->base.el->privdata[2] : NULL;
-            if (l) listDelNode(l, cc->pending_list_node);
-        }
         zfree(cc);
     }
 
@@ -445,12 +558,12 @@ void clientDisableCompression(client *c) {
     c->io_flags &= ~CLIENT_IO_COMPRESSION_ENABLED;
 }
 
-/* Compress any data send for compression by consumeAndTryWriteCompressed and
+/* Compress any data send for compression (see connCompressionWrite) and
  * write to socket. Zlib may not return compressed data immediately so this
  * call may not write anything to socket.
  * Force flushes the compressed buffer according to compression_max_latency.
  * Return number of bytes written to socket or -1 on socket write error. */
-int compressAndWrite(client *c) {
+int compressAndWrite(client *c, int *tot_written) {
     if (c->compression_level <= 0)
         return 0;
 
@@ -477,35 +590,34 @@ int compressAndWrite(client *c) {
             serverLog(LL_WARNING, "Flush compress error: %s (%d)",
                       state->zlib.msg, err);
             clientDestroyCompressionState(c);
-            return -1;
+            return 1;
         }
     }
 
+    compressionConnection *cc = (compressionConnection*)c->conn;
+
     /* Try to write all the data available in the compressed buffer. */
-    int tot_written = 0;
+    *tot_written = 0;
     int towrite =
         state->zlib.next_out - (state->compressed.data + state->compressed.used);
     while (towrite > 0) {
         int written = connWrite(
-            c->conn, state->compressed.data + state->compressed.used, towrite);
+            cc->underlying, state->compressed.data + state->compressed.used, towrite);
         if (written < 0) {
-            return written;
+            return 1;
         }
 
         // if (written > 0) {
         //     char *buf = zmalloc(written + 1);
         //     memcpy(buf, state->compressed.data+state->compressed.used, written);
         //     buf[written] = 0;
-        //     printf("\nWRITTEN: %s\n", buf);
+        //     printf("", buf);
         //     zfree(buf);
         // }
 
-        if (written > 0) {
-            state->compressed.used += written;
-            tot_written += written;
-            towrite -= written;
-
-        }
+        state->compressed.used += written;
+        *tot_written += written;
+        towrite -= written;
 
         /* All of the compressed data was send to the socket so we need to reset
          * the compression buffer. */
@@ -518,64 +630,10 @@ int compressAndWrite(client *c) {
         }
     }
 
-    if (tot_written > 0)
+    if (*tot_written > 0)
         state->last_write = mstime();
 
-    return tot_written;
-}
-
-/* Consume bytes from the `data` buffer, then try to compress and write to the
- * client's connection. Zlib may not return compressed data immediately so this
- * call may not write anything to socket.
- * Return number of bytes consumed from `data`. `nwritten` must be a valid
- * pointer - it is incremented by the number of bytes written to socket or set
- * to -1 on socket write error. */
-int consumeAndTryWriteCompressed(client *c, const char *data, size_t len,
-                                 ssize_t *nwritten) {
-    serverAssert(nwritten);
-
-    compressionState *state = c->compression_state;
-    serverAssert(state);
-
-    int consumed = 0;
-    while ((size_t)consumed != len) {
-        int to_consume =
-            min(ZLIB_TEMP_BUF_SIZE - state->uncompressed.used,
-                (int)(len - consumed));
-
-        memcpy(state->uncompressed.data + state->uncompressed.used,
-               data + consumed, to_consume);
-
-        serverAssert(to_consume >= 0);
-
-        // if (to_consume > 0) {
-        //     char *buf = zmalloc(to_consume + 1);
-        //     memcpy(buf, data+consumed, to_consume);
-        //     buf[to_consume] = 0;
-        //     printf("\nCONSUMED: %s\n", buf);
-        // }
-
-        state->uncompressed.used += to_consume;
-        consumed += to_consume;
-        state->zlib.avail_in += to_consume;
-
-        /* Write whatever we have available in the compressed buffer */
-        int written = compressAndWrite(c);
-        if (written < 0) {
-            if (connGetState(c->conn) != CONN_STATE_CONNECTED) {
-                *nwritten = -1;
-                return -1;
-            }
-            // *nwritten = -1;
-            return consumed;
-        }
-        *nwritten += written;
-
-        if (written == 0)
-            break;
-    }
-
-    return consumed;
+    return 0;
 }
 
 int decompressInto(compressionState *state, char *buf, size_t buflen) {
@@ -642,90 +700,13 @@ int decompressInto(compressionState *state, char *buf, size_t buflen) {
     return consumed;
 }
 
-/* Read data from client connection and decompress it immediately. The result is
- * written into buf.
- * Return number of bytes decompressed. *nread stores number of bytes read from
- * the socket or -1 on socket read error.
- * Note, that we may have enough compressed data on the socket that decompressing
- * it will exceed buflen. To handle decompressed data without readQueryFromClient
- * being called from a read handler, the readQueryFromClient is called in an
- * IO-thread cron with the client->flag & CLIENT_IO_READ_DECOMPRESSED_CRON. With
- * that flag raised we don't read from socket - we only read any available
- * decompressed data. */
-int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *net_read) {
-    compressionState *state = c->compression_state;
-
-    int tot_decompressed = 0;
-
-    /* Defaulting to -1 since we first try to decompress any available data.
-     * If anything fails -1 indicates we haven't read anything from socket. */
-    *net_read = -1;
-    if (c->io_flags & CLIENT_IO_READ_DECOMPRESSED_CRON &&
-        (state->zlib.next_out - (state->uncompressed.data + state->uncompressed.used) <= 0))
-    {
-        return -1;
-    }
-
-    /* Try to read any available decompressed data */
-    int written = decompressInto(state, buf, buflen);
-    if (written == -1) {
-        return -1;
-    }
-    tot_decompressed += written;
-
-    /* In case we are here because a cron function called readQueryFromClient
-     * that means we only need to read any available decompressed data.
-     * We don't try to read from socket in this case as this function is
-     * not handling a read. */
-    if (c->io_flags & CLIENT_IO_READ_DECOMPRESSED_CRON) {
-        return tot_decompressed;
-    }
-
-    /* Now we start reading from socket so reset to 0 in order to properly count
-     * how many bytes were read. */
-    *net_read = 0;
-    do {
-        /* Read data from socket and save it inside the compressed buffer */
-        int nread =
-            connRead(c->conn, state->compressed.data + state->compressed.used,
-                    ZLIB_TEMP_BUF_SIZE - state->compressed.used);
-
-        if (nread < 0 && connGetState(c->conn) == CONN_STATE_ERROR) {
-            serverLog(LL_NOTICE, "Compressed read error: %s", strerror(errno));
-            return -1;
-        }
-
-        // if (nread > 0) {
-        //     char *buf = zmalloc(nread + 1);
-        //     memcpy(buf, state->compressed.data+state->compressed.used, nread);
-        //     buf[nread] = 0;
-        //     printf("\nNREAD: %s\n", buf);
-        // }
-
-        /* We can continue decompressing in case of non-fatal error */
-        if (nread > 0) {
-            state->compressed.used += nread;
-            state->zlib.avail_in += nread;
-            *net_read += nread;
-        }
-
-        int decompressed = decompressInto(state, buf + tot_decompressed,
-                                          buflen - tot_decompressed);
-        if (decompressed <= 0)
-            break;
-        tot_decompressed += decompressed;
-    } while ((size_t)tot_decompressed < buflen && state->zlib.avail_in > 0);
-
-    /* connRead may return -1 with EAGAIN in which case *net_read will not be
-     * updated. We strive to return the same as connRead so we fix it here. */
-    if (*net_read == 0 && connGetState(c->conn) == CONN_STATE_CONNECTED)
-        *net_read = -1;
-
-    return tot_decompressed;
-}
-
-/* Same as readFromSocketAndDecompress but reads from `input_buf` instead of
- * socket. */
+/* Read data from input_buf and decompress it immediately. The result is written
+ * into output_buf.
+ * Return number of bytes decompressed. *consumed stores number of bytes consumed
+ * from input_buf.
+ * Note, that we may have enough compressed data inside input buf so that decompressing
+ * it will exceed output_len. The function must be ran in a loop until input_buf
+ * is fully consumed - so make sure to have free space in output_buf on each call. */
 int readFromBufAndDecompress(client *c, char *input_buf, size_t input_len,
                              char *output_buf, size_t output_len, size_t *consumed)
 {

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -262,7 +262,7 @@ int consumeAndTryWriteCompressed(client *c, char *data, size_t len,
                 *nwritten = -1;
                 return -1;
             }
-            *nwritten = -1;
+            // *nwritten = -1;
             return consumed;
         }
         *nwritten += written;

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -29,7 +29,7 @@ struct compressionState {
         z_stream zlib;            /* Zlib state */
         ZSTD_CStream *zstdCCtx;  /* Zstd compression ctx */
         ZSTD_DStream *zstdDCtx;  /* Zstd decompression ctx */
-    };
+    } ctx;
     int write_flush_pending;    /* zstd: flush not yet completed, keep calling with ZSTD_e_flush */
     int read_flush_pending;    /* zstd: flush not yet completed, keep calling with ZSTD_e_flush */
     mstime_t last_write;  /* Time since last write. Used to check if it's time
@@ -50,11 +50,11 @@ static void zlib_free_wrapper(void *opaque, void *address) {
 }
 
 static int zlibInitCompress(compressionState *st, int level) {
-    st->zlib.zalloc = zlib_alloc_wrapper;
-    st->zlib.zfree = zlib_free_wrapper;
+    st->ctx.zlib.zalloc = zlib_alloc_wrapper;
+    st->ctx.zlib.zfree = zlib_free_wrapper;
 
-    if (deflateInit(&st->zlib, level) != Z_OK) {
-        serverLog(LL_NOTICE, "Failed to initialize zlib compression: %s", st->zlib.msg);
+    if (deflateInit(&st->ctx.zlib, level) != Z_OK) {
+        serverLog(LL_NOTICE, "Failed to initialize zlib compression: %s", st->ctx.zlib.msg);
         return -1;
     }
 
@@ -62,24 +62,24 @@ static int zlibInitCompress(compressionState *st, int level) {
     st->output.size = ZLIB_TEMP_BUF_SIZE;
     st->output.written = 0;
     st->output.consumed = 0;
-    st->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
-    st->zlib.next_out = st->output.data;
+    st->ctx.zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
+    st->ctx.zlib.next_out = st->output.data;
 
     st->input.data = zmalloc(ZLIB_TEMP_BUF_SIZE);
     st->input.size = ZLIB_TEMP_BUF_SIZE;
     st->input.written = 0;
     st->input.consumed = 0;
-    st->zlib.avail_in = 0;
-    st->zlib.next_in = st->input.data;
+    st->ctx.zlib.avail_in = 0;
+    st->ctx.zlib.next_in = st->input.data;
 
     return 0;
 }
 
 static int zlibInitDecompress(compressionState *st) {
-    st->zlib.zalloc = zlib_alloc_wrapper;
-    st->zlib.zfree = zlib_free_wrapper;
-    if (inflateInit(&st->zlib) != Z_OK) {
-        serverLog(LL_NOTICE, "Failed to initialize zlib decompression: %s", st->zlib.msg);
+    st->ctx.zlib.zalloc = zlib_alloc_wrapper;
+    st->ctx.zlib.zfree = zlib_free_wrapper;
+    if (inflateInit(&st->ctx.zlib) != Z_OK) {
+        serverLog(LL_NOTICE, "Failed to initialize zlib decompression: %s", st->ctx.zlib.msg);
         return -1;
     }
 
@@ -87,60 +87,60 @@ static int zlibInitDecompress(compressionState *st) {
     st->input.size = ZLIB_TEMP_BUF_SIZE;
     st->input.written = 0;
     st->input.consumed = 0;
-    st->zlib.avail_in = 0;
-    st->zlib.next_in = st->input.data;
+    st->ctx.zlib.avail_in = 0;
+    st->ctx.zlib.next_in = st->input.data;
 
     st->output.data = zmalloc(ZLIB_TEMP_BUF_SIZE);
     st->output.size = ZLIB_TEMP_BUF_SIZE;
     st->output.written = 0;
     st->output.consumed = 0;
-    st->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
-    st->zlib.next_out = st->output.data;
+    st->ctx.zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
+    st->ctx.zlib.next_out = st->output.data;
 
     return 0;
 }
 
 static int zlibCompress(compressionState *st, int flush) {
-    st->zlib.next_out = st->output.data + st->output.written;
-    st->zlib.avail_out = st->output.size - st->output.written;
-    st->zlib.next_in = st->input.data + st->input.consumed;
-    st->zlib.avail_in =  st->input.written - st->input.consumed;
+    st->ctx.zlib.next_out = st->output.data + st->output.written;
+    st->ctx.zlib.avail_out = st->output.size - st->output.written;
+    st->ctx.zlib.next_in = st->input.data + st->input.consumed;
+    st->ctx.zlib.avail_in =  st->input.written - st->input.consumed;
 
-    int err = deflate(&st->zlib, flush ? Z_SYNC_FLUSH : Z_NO_FLUSH);
+    int err = deflate(&st->ctx.zlib, flush ? Z_SYNC_FLUSH : Z_NO_FLUSH);
     if (err != Z_OK && err != Z_BUF_ERROR) {
-        serverLog(LL_WARNING, "zlib compress error: %s (%d)", st->zlib.msg, err);
+        serverLog(LL_WARNING, "zlib compress error: %s (%d)", st->ctx.zlib.msg, err);
         return -1;
     }
 
-    st->output.written = st->zlib.next_out - st->output.data;
-    st->input.consumed = st->zlib.next_in - st->input.data;
+    st->output.written = st->ctx.zlib.next_out - st->output.data;
+    st->input.consumed = st->ctx.zlib.next_in - st->input.data;
 
     return 0;
 }
 
 static int zlibDecompress(compressionState *st) {
-    st->zlib.next_in = st->input.data + st->input.consumed;
-    st->zlib.avail_in = st->input.written - st->input.consumed;
-    st->zlib.next_out = st->output.data + st->output.written;
-    st->zlib.avail_out = st->output.size - st->output.written;
+    st->ctx.zlib.next_in = st->input.data + st->input.consumed;
+    st->ctx.zlib.avail_in = st->input.written - st->input.consumed;
+    st->ctx.zlib.next_out = st->output.data + st->output.written;
+    st->ctx.zlib.avail_out = st->output.size - st->output.written;
 
-    int err = inflate(&st->zlib, Z_SYNC_FLUSH);
+    int err = inflate(&st->ctx.zlib, Z_SYNC_FLUSH);
     if (err != Z_OK && err != Z_BUF_ERROR) {
-        serverLog(LL_NOTICE, "zlib decompress error: %s (%d)", st->zlib.msg, err);
+        serverLog(LL_NOTICE, "zlib decompress error: %s (%d)", st->ctx.zlib.msg, err);
         return -1;
     }
 
-    st->output.written = st->zlib.next_out - st->output.data;
-    st->input.consumed = st->zlib.next_in - st->input.data;
+    st->output.written = st->ctx.zlib.next_out - st->output.data;
+    st->input.consumed = st->ctx.zlib.next_in - st->input.data;
 
     return 0;
 }
 
 static void zlibEnd(compressionState *st) {
     if (st->dir == COMPRESS)
-        deflateEnd(&st->zlib);
+        deflateEnd(&st->ctx.zlib);
     else if (st->dir == DECOMPRESS)
-        inflateEnd(&st->zlib);
+        inflateEnd(&st->ctx.zlib);
 }
 
 static const compressionType zlibType = {
@@ -154,12 +154,12 @@ static const compressionType zlibType = {
 /* --- zstd --- */
 
 static int zstdInitCompress(compressionState *st, int level) {
-    st->zstdCCtx = ZSTD_createCStream();
-    if (!st->zstdCCtx) {
+    st->ctx.zstdCCtx = ZSTD_createCStream();
+    if (!st->ctx.zstdCCtx) {
         serverLog(LL_NOTICE, "Failed to create ZSTD compression context");
         return -1;
     }
-    ZSTD_CCtx_setParameter(st->zstdCCtx, ZSTD_c_compressionLevel, level);
+    ZSTD_CCtx_setParameter(st->ctx.zstdCCtx, ZSTD_c_compressionLevel, level);
 
     size_t outSize = ZSTD_CStreamOutSize();
     st->output.data = zmalloc(outSize);
@@ -179,8 +179,8 @@ static int zstdInitCompress(compressionState *st, int level) {
 }
 
 static int zstdInitDecompress(compressionState *st) {
-    st->zstdDCtx = ZSTD_createDStream();
-    if (!st->zstdDCtx) {
+    st->ctx.zstdDCtx = ZSTD_createDStream();
+    if (!st->ctx.zstdDCtx) {
         serverLog(LL_NOTICE, "Failed to create ZSTD decompression context");
         return -1;
     }
@@ -222,7 +222,7 @@ static int zstdCompress(compressionState *st, int flush) {
 
     size_t ret;
     do {
-        ret = ZSTD_compressStream2(st->zstdCCtx, &output, &input, directive);
+        ret = ZSTD_compressStream2(st->ctx.zstdCCtx, &output, &input, directive);
         if (ZSTD_isError(ret)) {
             serverLog(LL_WARNING, "zstd compress error: %s", ZSTD_getErrorName(ret));
             return -1;
@@ -249,7 +249,7 @@ static int zstdDecompress(compressionState *st) {
         .pos  = st->output.written
     };
 
-    size_t ret = ZSTD_decompressStream(st->zstdDCtx, &output, &input);
+    size_t ret = ZSTD_decompressStream(st->ctx.zstdDCtx, &output, &input);
     if (ZSTD_isError(ret)) {
         serverLog(LL_NOTICE, "zstd decompress error: %s", ZSTD_getErrorName(ret));
         return -1;
@@ -266,10 +266,10 @@ static int zstdDecompress(compressionState *st) {
 }
 
 static void zstdEnd(compressionState *st) {
-    if (st->dir == COMPRESS && st->zstdCCtx)
-        ZSTD_freeCStream(st->zstdCCtx);
-    else if (st->dir == DECOMPRESS && st->zstdDCtx)
-        ZSTD_freeDStream(st->zstdDCtx);
+    if (st->dir == COMPRESS && st->ctx.zstdCCtx)
+        ZSTD_freeCStream(st->ctx.zstdCCtx);
+    else if (st->dir == DECOMPRESS && st->ctx.zstdDCtx)
+        ZSTD_freeDStream(st->ctx.zstdDCtx);
 }
 
 static const compressionType zstdType = {

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -293,7 +293,7 @@ static int connCompressionGetIovcnt(connection *conn) {
     return cc->underlying->iovcnt;
 }
 
-static int connCompressionGetState(connection *conn) {
+static ConnectionState connCompressionGetState(connection *conn) {
     compressionConnection *cc = (compressionConnection*)conn;
     return cc->underlying->state;
 }

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -159,7 +159,12 @@ static int zstdInitCompress(compressionState *st, int level) {
         serverLog(LL_NOTICE, "Failed to create ZSTD compression context");
         return -1;
     }
-    ZSTD_CCtx_setParameter(st->ctx.zstdCCtx, ZSTD_c_compressionLevel, level);
+    size_t res = ZSTD_CCtx_setParameter(st->ctx.zstdCCtx, ZSTD_c_compressionLevel, level);
+    if (ZSTD_isError(res)) {
+        ZSTD_freeCStream(st->ctx.zstdCCtx);
+        serverLog(LL_NOTICE, "Failed to set compression level for ZSTD compression context");
+        return -1;
+    }
 
     size_t outSize = ZSTD_CStreamOutSize();
     st->output.data = zmalloc(outSize);
@@ -215,8 +220,14 @@ static int zstdCompress(compressionState *st, int flush) {
     };
 
     ZSTD_EndDirective directive;
+    /* We use ZSTD_e_end instead of ZSTD_e_flush when we want to flush zstd's.
+     * This flushes zstd's internal buffers but also ends the current frame.
+     * This of couse lowers the compression ratio but massively increases speed
+     * on the decompression side also, as it doesnt need to wait for more data.
+     * The resulting compression ratio is still very good (tested with default
+     * compression level). */
     if (flush || st->write_flush_pending)
-        directive = ZSTD_e_flush;
+        directive = ZSTD_e_end;
     else
         directive = ZSTD_e_continue;
 
@@ -227,9 +238,13 @@ static int zstdCompress(compressionState *st, int flush) {
             serverLog(LL_WARNING, "zstd compress error: %s", ZSTD_getErrorName(ret));
             return -1;
         }
-    } while (directive == ZSTD_e_flush && ret > 0 && output.pos < output.size);
+    } while (/*directive == ZSTD_e_end && */ret > 0 && output.pos < output.size);
 
-    st->write_flush_pending = (directive == ZSTD_e_flush && ret > 0);
+    /* If we pass a directive differnt than ZSTD_e_continue to zstd we want to
+     * keep using that directive until compressStream2 returns 0. By keeping
+     * this flag raised we know we are in the process of flushing data, i.e we
+     * cannot use ZSTD_e_continue before we have flushed it all. */
+    st->write_flush_pending = (directive == ZSTD_e_end && ret > 0);
 
     st->input.consumed = input.pos;
     st->output.written = output.pos;
@@ -266,10 +281,32 @@ static int zstdDecompress(compressionState *st) {
 }
 
 static void zstdEnd(compressionState *st) {
-    if (st->dir == COMPRESS && st->ctx.zstdCCtx)
+    if (st->dir == COMPRESS && st->ctx.zstdCCtx) {
+        if (st->write_flush_pending) {
+            size_t sz = ZSTD_CStreamOutSize();
+            char *tmp = zmalloc(sz);
+            ZSTD_inBuffer input = {
+                .src  = NULL,
+                .size = 0,
+                .pos  = 0
+            };
+            ZSTD_outBuffer output = {
+                .dst  = tmp,
+                .size = sz,
+                .pos  = 0
+            };
+            while (ZSTD_compressStream2(st->ctx.zstdCCtx, &output, &input, ZSTD_e_end) > 0) {
+                /* Just ignore the output, we are closing the compression state
+                 * anyways */
+                output.pos = 0;
+            }
+        }
         ZSTD_freeCStream(st->ctx.zstdCCtx);
-    else if (st->dir == DECOMPRESS && st->ctx.zstdDCtx)
+        st->ctx.zstdCCtx = NULL;
+    } else if (st->dir == DECOMPRESS && st->ctx.zstdDCtx) {
         ZSTD_freeDStream(st->ctx.zstdDCtx);
+        st->ctx.zstdDCtx = NULL;
+    }
 }
 
 static const compressionType zstdType = {
@@ -295,8 +332,9 @@ int decompressInto(compressionState *state, char *buf, size_t buflen);
 static void compressionPendingAdd(compressionConnection *cc) {
     if (cc->pending_data_node) return;
 
-    if (!cc->underlying->el->privdata[2])
+    if (!cc->underlying->el->privdata[2]) {
         cc->underlying->el->privdata[2] = listCreate();
+    }
 
     list *l = cc->underlying->el->privdata[2];
     listAddNodeTail(l, cc);
@@ -304,9 +342,14 @@ static void compressionPendingAdd(compressionConnection *cc) {
 }
 
 static void compressionPendingRemove(compressionConnection *cc) {
+    if (!cc->pending_data_node) return;
+
     list *l = cc->underlying->el->privdata[2];
-    if (!l || listLength(l) == 0) return;
-    listDelNode(l, cc->pending_data_node);
+    if (l && listLength(l) > 0 && listSearchKey(l, cc) == cc->pending_data_node) {
+        listDelNode(l, cc->pending_data_node);
+    } else if (cc->pending_data_node) {
+        zfree(cc->pending_data_node);
+    }
     cc->pending_data_node = NULL;
 }
 
@@ -411,10 +454,14 @@ static int connCompressionRead(struct connection *conn, void *buf, size_t buf_le
     if (decompressed == 0 && connGetState(cc->underlying) == CONN_STATE_CONNECTED)
         return -1;
 
-    if (connGetState(conn) == CONN_STATE_CONNECTED && clientHasPendingCompressedData(c)) {
-        compressionPendingAdd(cc);
-    } else {
-        compressionPendingRemove(cc);
+    /* No need to give pending work to main thread as the client must be send to
+     * IO-thread soon enough. */
+    if (c->running_tid != IOTHREAD_MAIN_THREAD_ID) {
+        if (connGetState(conn) == CONN_STATE_CONNECTED && clientHasPendingCompressedData(c)) {
+            compressionPendingAdd(cc);
+        } else if (cc->pending_data_node) {
+            compressionPendingRemove(cc);
+        }
     }
 
     return decompressed;
@@ -521,9 +568,10 @@ static void connCompressionUnbindEventLoop(connection *conn) {
         int mask = aeGetFileEvents(el, cc->underlying->fd);
         if (mask & AE_READABLE) aeDeleteFileEvent(el, fd, AE_READABLE);
         if (mask & AE_WRITABLE) aeDeleteFileEvent(el, fd, AE_WRITABLE);
-    }
-    if (cc->pending_data_node) {
-        compressionPendingRemove(cc);
+
+        if (cc->pending_data_node) {
+            compressionPendingRemove(cc);
+        }
     }
 }
 
@@ -600,7 +648,7 @@ static int compressionProcessPendingData(struct aeEventLoop *el) {
     listRewind(pending_list,&li);
     while((ln = listNext(&li))) {
         compressionConnection *cc = listNodeValue(ln);
-        if (!cc || !connHasReadHandler((connection*)cc)) continue;
+        if (!cc || !cc->underlying || !connHasReadHandler((connection*)cc)) continue;
 
         cc->handle_pending = 1;
         cc->underlying->read_handler(cc->underlying);
@@ -728,6 +776,7 @@ int clientCreateCompressionState(client *c, compressionDirection dir) {
 
         serverLog(LL_NOTICE, "Decompression for master client initialized.");
     } else {
+        /* Inaccessible */
         serverAssert(0);
     }
 
@@ -876,7 +925,7 @@ int decompressInto(compressionState *state, char *buf, size_t buflen) {
         }
 
         if ((state->read_flush_pending && state->output.size > state->output.written) ||
-            state->input.written > state->input.consumed)
+             state->input.written > state->input.consumed)
         {
             if (state->type->decompress(state) == -1) {
                 return -1;
@@ -979,7 +1028,7 @@ int clientHasPendingCompressedData(client *c) {
     if (!state) return 0;
     if (state->dir != DECOMPRESS) return 0;
 
-    return state->read_flush_pending ||
+    return (state->read_flush_pending && state->output.size > state->output.written) ||
            state->input.written > state->input.consumed ||
            state->output.written > state->output.consumed;
 }

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -399,15 +399,9 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *net_re
             connRead(c->conn, state->compressed.data + state->compressed.used,
                     ZLIB_TEMP_BUF_SIZE - state->compressed.used);
 
-        if (nread <= 0) {
-            if (nread < 0 && connGetState(c->conn) == CONN_STATE_ERROR) {
-                serverLog(LL_NOTICE, "Compressed read error: %s", strerror(errno));
-                return -1;
-            }
-
-            /* If no error just continue - we may have some more data to
-             * decompress even if the connection was closed. */
-            nread = 0;
+        if (nread < 0 && connGetState(c->conn) == CONN_STATE_ERROR) {
+            serverLog(LL_NOTICE, "Compressed read error: %s", strerror(errno));
+            return -1;
         }
 
         // if (nread > 0) {
@@ -417,9 +411,12 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *net_re
         //     printf("\nNREAD: %s\n", buf);
         // }
 
-        state->compressed.used += nread;
-        state->zlib.avail_in += nread;
-        *net_read += nread;
+        /* We can continue decompressing in case of non-fatal error */
+        if (nread > 0) {
+            state->compressed.used += nread;
+            state->zlib.avail_in += nread;
+            *net_read += nread;
+        }
 
         int decompressed = decompressInto(c, buf + tot_decompressed,
                                           buflen - tot_decompressed);
@@ -428,7 +425,9 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *net_re
         tot_decompressed += decompressed;
     } while ((size_t)tot_decompressed < buflen && state->zlib.avail_in > 0);
 
-    if (*net_read == 0 && c->conn->state == CONN_STATE_CONNECTED)
+    /* connRead may return -1 with EAGAIN in which case *net_read will not be
+     * updated. We strive to return the same as connRead so we fix it here. */
+    if (*net_read == 0 && connGetState(c->conn) == CONN_STATE_CONNECTED)
         *net_read = -1;
 
     return tot_decompressed;
@@ -436,7 +435,7 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *net_re
 
 /* Same as readFromSocketAndDecompress but reads from `input_buf` instead of
  * socket. */
-int readFromBufAndDecompress(struct client *c, char *input_buf, size_t input_len,
+int readFromBufAndDecompress(client *c, char *input_buf, size_t input_len,
                              char *output_buf, size_t output_len, size_t *consumed)
 {
     compressionState *state = c->compression_state;
@@ -468,5 +467,23 @@ int readFromBufAndDecompress(struct client *c, char *input_buf, size_t input_len
 
     return tot_decompressed;
 
+}
+
+int clientHasPendingCompressionFlush(client *c) {
+    compressionState *state = c->compression_state;
+    if (!state) return 0;
+    if (!state->deflate_inited) return 0;
+
+    // return state->zlib.avail_out > 0 || (state->zlib.next_out - (state->compressed.data + state->compressed.used) > 0);
+    return mstime() - state->last_write >= server.compression_max_latency;
+}
+
+int clientHasPendingCompressedData(client *c) {
+    compressionState *state = c->compression_state;
+    if (!state) return 0;
+    if (!state->inflate_inited) return 0;
+
+    return state->zlib.avail_in > 0 ||
+           state->zlib.next_out > state->uncompressed.data + state->uncompressed.used;
 }
 

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -1,23 +1,283 @@
 #include "server.h"
 #include "client_comp.h"
 #include <zlib.h>
+#include <zstd.h>
 
-/* Main compression state struct */
 #define ZLIB_TEMP_BUF_SIZE 16 * 1024
 
+typedef struct compressionType {
+    int (*init_compress)(struct compressionState *st, int level);
+    int (*init_decompress)(struct compressionState *st);
+    int (*compress)(struct compressionState *st, int flush);
+    int (*decompress)(struct compressionState *st);
+    void (*end)(struct compressionState *st);
+} compressionType;
+
 typedef struct {
-    unsigned char data[ZLIB_TEMP_BUF_SIZE];
-    int used;
+    unsigned char *data;
+    int size;
+    int written;
+    int consumed;
 } tempBuf;
 
+/* Main compression state struct */
 struct compressionState {
-    client *client;
-    tempBuf compressed;   /* Buffer holding compressed data */
-    tempBuf uncompressed; /* Buffer holding uncompressed(decompressed) data */
-    z_stream zlib;        /* Zlib state */
+    const compressionType *type;
+    tempBuf input;  /* Buffer holding compressed data */
+    tempBuf output; /* Buffer holding uncompressed(decompressed) data */
+    union {
+        z_stream zlib;            /* Zlib state */
+        ZSTD_CStream *zstdCCtx;  /* Zstd compression ctx */
+        ZSTD_DStream *zstdDCtx;  /* Zstd decompression ctx */
+    };
+    int write_flush_pending;    /* zstd: flush not yet completed, keep calling with ZSTD_e_flush */
+    int read_flush_pending;    /* zstd: flush not yet completed, keep calling with ZSTD_e_flush */
     mstime_t last_write;  /* Time since last write. Used to check if it's time
                            * to flush the buffer */
     compressionDirection dir;
+};
+
+/* --- zlib --- */
+static void *zlib_alloc_wrapper(void *opaque, unsigned int items,
+                                unsigned int size) {
+    UNUSED(opaque);
+    return zmalloc(items * size);
+}
+
+static void zlib_free_wrapper(void *opaque, void *address) {
+    UNUSED(opaque);
+    zfree(address);
+}
+
+static int zlibInitCompress(compressionState *st, int level) {
+    st->zlib.zalloc = zlib_alloc_wrapper;
+    st->zlib.zfree = zlib_free_wrapper;
+
+    if (deflateInit(&st->zlib, level) != Z_OK) {
+        serverLog(LL_NOTICE, "Failed to initialize zlib compression: %s", st->zlib.msg);
+        return -1;
+    }
+
+    st->output.data = zmalloc(ZLIB_TEMP_BUF_SIZE);
+    st->output.size = ZLIB_TEMP_BUF_SIZE;
+    st->output.written = 0;
+    st->output.consumed = 0;
+    st->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
+    st->zlib.next_out = st->output.data;
+
+    st->input.data = zmalloc(ZLIB_TEMP_BUF_SIZE);
+    st->input.size = ZLIB_TEMP_BUF_SIZE;
+    st->input.written = 0;
+    st->input.consumed = 0;
+    st->zlib.avail_in = 0;
+    st->zlib.next_in = st->input.data;
+
+    return 0;
+}
+
+static int zlibInitDecompress(compressionState *st) {
+    st->zlib.zalloc = zlib_alloc_wrapper;
+    st->zlib.zfree = zlib_free_wrapper;
+    if (inflateInit(&st->zlib) != Z_OK) {
+        serverLog(LL_NOTICE, "Failed to initialize zlib decompression: %s", st->zlib.msg);
+        return -1;
+    }
+
+    st->input.data = zmalloc(ZLIB_TEMP_BUF_SIZE);
+    st->input.size = ZLIB_TEMP_BUF_SIZE;
+    st->input.written = 0;
+    st->input.consumed = 0;
+    st->zlib.avail_in = 0;
+    st->zlib.next_in = st->input.data;
+
+    st->output.data = zmalloc(ZLIB_TEMP_BUF_SIZE);
+    st->output.size = ZLIB_TEMP_BUF_SIZE;
+    st->output.written = 0;
+    st->output.consumed = 0;
+    st->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
+    st->zlib.next_out = st->output.data;
+
+    return 0;
+}
+
+static int zlibCompress(compressionState *st, int flush) {
+    st->zlib.next_out = st->output.data + st->output.written;
+    st->zlib.avail_out = st->output.size - st->output.written;
+    st->zlib.next_in = st->input.data + st->input.consumed;
+    st->zlib.avail_in =  st->input.written - st->input.consumed;
+
+    int err = deflate(&st->zlib, flush ? Z_SYNC_FLUSH : Z_NO_FLUSH);
+    if (err != Z_OK && err != Z_BUF_ERROR) {
+        serverLog(LL_WARNING, "zlib compress error: %s (%d)", st->zlib.msg, err);
+        return -1;
+    }
+
+    st->output.written = st->zlib.next_out - st->output.data;
+    st->input.consumed = st->zlib.next_in - st->input.data;
+
+    return 0;
+}
+
+static int zlibDecompress(compressionState *st) {
+    st->zlib.next_in = st->input.data + st->input.consumed;
+    st->zlib.avail_in = st->input.written - st->input.consumed;
+    st->zlib.next_out = st->output.data + st->output.written;
+    st->zlib.avail_out = st->output.size - st->output.written;
+
+    int err = inflate(&st->zlib, Z_SYNC_FLUSH);
+    if (err != Z_OK && err != Z_BUF_ERROR) {
+        serverLog(LL_NOTICE, "zlib decompress error: %s (%d)", st->zlib.msg, err);
+        return -1;
+    }
+
+    st->output.written = st->zlib.next_out - st->output.data;
+    st->input.consumed = st->zlib.next_in - st->input.data;
+
+    return 0;
+}
+
+static void zlibEnd(compressionState *st) {
+    if (st->dir == COMPRESS)
+        deflateEnd(&st->zlib);
+    else if (st->dir == DECOMPRESS)
+        inflateEnd(&st->zlib);
+}
+
+static const compressionType zlibType = {
+    .init_compress = zlibInitCompress,
+    .init_decompress = zlibInitDecompress,
+    .compress = zlibCompress,
+    .decompress = zlibDecompress,
+    .end = zlibEnd,
+};
+
+/* --- zstd --- */
+
+static int zstdInitCompress(compressionState *st, int level) {
+    st->zstdCCtx = ZSTD_createCStream();
+    if (!st->zstdCCtx) {
+        serverLog(LL_NOTICE, "Failed to create ZSTD compression context");
+        return -1;
+    }
+    ZSTD_CCtx_setParameter(st->zstdCCtx, ZSTD_c_compressionLevel, level);
+
+    size_t outSize = ZSTD_CStreamOutSize();
+    st->output.data = zmalloc(outSize);
+    st->output.size = outSize;
+    st->output.written = 0;
+    st->output.consumed = 0;
+
+    size_t inSize = ZSTD_CStreamInSize();
+    st->input.data = zmalloc(inSize);
+    st->input.size = inSize;
+    st->input.written = 0;
+    st->input.consumed = 0;
+
+    st->write_flush_pending = 0;
+
+    return 0;
+}
+
+static int zstdInitDecompress(compressionState *st) {
+    st->zstdDCtx = ZSTD_createDStream();
+    if (!st->zstdDCtx) {
+        serverLog(LL_NOTICE, "Failed to create ZSTD decompression context");
+        return -1;
+    }
+
+    size_t inSize = ZSTD_DStreamInSize();
+    st->input.data = zmalloc(inSize);
+    st->input.size = inSize;
+    st->input.written = 0;
+    st->input.consumed = 0;
+
+    size_t outSize = ZSTD_DStreamOutSize();
+    st->output.data = zmalloc(outSize);
+    st->output.size = outSize;
+    st->output.written = 0;
+    st->output.consumed = 0;
+
+    st->read_flush_pending = 0;
+
+    return 0;
+}
+
+static int zstdCompress(compressionState *st, int flush) {
+    ZSTD_inBuffer input = {
+        .src  = st->input.data,
+        .size = st->input.written,
+        .pos  = st->input.consumed
+    };
+    ZSTD_outBuffer output = {
+        .dst  = st->output.data,
+        .size = st->output.size,
+        .pos  = st->output.written
+    };
+
+    ZSTD_EndDirective directive;
+    if (flush || st->write_flush_pending)
+        directive = ZSTD_e_flush;
+    else
+        directive = ZSTD_e_continue;
+
+    size_t ret;
+    do {
+        ret = ZSTD_compressStream2(st->zstdCCtx, &output, &input, directive);
+        if (ZSTD_isError(ret)) {
+            serverLog(LL_WARNING, "zstd compress error: %s", ZSTD_getErrorName(ret));
+            return -1;
+        }
+    } while (directive == ZSTD_e_flush && ret > 0 && output.pos < output.size);
+
+    st->write_flush_pending = (directive == ZSTD_e_flush && ret > 0);
+
+    st->input.consumed = input.pos;
+    st->output.written = output.pos;
+
+    return 0;
+}
+
+static int zstdDecompress(compressionState *st) {
+    ZSTD_inBuffer input = {
+        .src  = st->input.data,
+        .size = st->input.written,
+        .pos  = st->input.consumed
+    };
+    ZSTD_outBuffer output = {
+        .dst  = st->output.data,
+        .size = st->output.size,
+        .pos  = st->output.written
+    };
+
+    size_t ret = ZSTD_decompressStream(st->zstdDCtx, &output, &input);
+    if (ZSTD_isError(ret)) {
+        serverLog(LL_NOTICE, "zstd decompress error: %s", ZSTD_getErrorName(ret));
+        return -1;
+    }
+
+    /* Don't try to flush again if we already tried, no more progress can be
+     * made without additional input. */
+    st->read_flush_pending = !st->read_flush_pending && (ret > 0);
+
+    st->input.consumed = input.pos;
+    st->output.written = output.pos;
+
+    return 0;
+}
+
+static void zstdEnd(compressionState *st) {
+    if (st->dir == COMPRESS && st->zstdCCtx)
+        ZSTD_freeCStream(st->zstdCCtx);
+    else if (st->dir == DECOMPRESS && st->zstdDCtx)
+        ZSTD_freeDStream(st->zstdDCtx);
+}
+
+static const compressionType zstdType = {
+    .init_compress = zstdInitCompress,
+    .init_decompress = zstdInitDecompress,
+    .compress = zstdCompress,
+    .decompress = zstdDecompress,
+    .end = zstdEnd,
 };
 
 /* Compression connection */
@@ -122,12 +382,12 @@ static int connCompressionRead(struct connection *conn, void *buf, size_t buf_le
         if (!cc->handle_pending) {
             nread = cc->underlying->type->read(
                 cc->underlying,
-                state->compressed.data + state->compressed.used,
-                ZLIB_TEMP_BUF_SIZE - state->compressed.used);
+                state->input.data + state->input.written,
+                state->input.size - state->input.written);
 
             // if (nread > 0) {
             //     char *buf = zmalloc(nread + 1);
-            //     memcpy(buf, state->compressed.data+state->compressed.used, nread);
+            //     memcpy(buf, state->input.data+state->input.written, nread);
             //     buf[nread] = 0;
             //     printf("\nNREAD: %s\n", buf);
             //     zfree(buf);
@@ -141,8 +401,7 @@ static int connCompressionRead(struct connection *conn, void *buf, size_t buf_le
              * nothing more it can do. */
             if (nread > 0) {
                 cc->last_read += nread;
-                state->compressed.used += nread;
-                state->zlib.avail_in += nread;
+                state->input.written += nread;
             }
         }
 
@@ -152,7 +411,7 @@ static int connCompressionRead(struct connection *conn, void *buf, size_t buf_le
     if (decompressed == 0 && connGetState(cc->underlying) == CONN_STATE_CONNECTED)
         return -1;
 
-    if (clientHasPendingCompressedData(c)) {
+    if (connGetState(conn) == CONN_STATE_CONNECTED && clientHasPendingCompressedData(c)) {
         compressionPendingAdd(cc);
     } else {
         compressionPendingRemove(cc);
@@ -174,22 +433,22 @@ static int connCompressionWrite(connection *conn, const void *data, size_t len) 
     cc->last_written = 0;
     while ((size_t)consumed != len) {
         int to_consume =
-            min(ZLIB_TEMP_BUF_SIZE - state->uncompressed.used, (int)(len - consumed));
+            min(state->input.size - state->input.written, (int)(len - consumed));
         serverAssert(to_consume >= 0);
 
-        memcpy(state->uncompressed.data + state->uncompressed.used,
+        memcpy(state->input.data + state->input.written,
                (char*)data + consumed, to_consume);
 
         // if (to_consume > 0) {
         //     char *buf = zmalloc(to_consume + 1);
-        //     memcpy(buf, data+consumed, to_consume);
+        //     memcpy(buf, (char*)data+consumed, to_consume);
         //     buf[to_consume] = 0;
         //     printf("\nCONSUMED: %s\n", buf);
+        //     zfree(buf);
         // }
 
-        state->uncompressed.used += to_consume;
+        state->input.written += to_consume;
         consumed += to_consume;
-        state->zlib.avail_in += to_consume;
 
         /* Write whatever we have available in the compressed buffer */
         int written = 0;
@@ -202,7 +461,7 @@ static int connCompressionWrite(connection *conn, const void *data, size_t len) 
             return consumed;
         }
 
-        if (written == 0)
+        if (written == 0 && state->output.written == state->output.consumed)
             break;
     }
 
@@ -341,7 +600,7 @@ static int compressionProcessPendingData(struct aeEventLoop *el) {
     listRewind(pending_list,&li);
     while((ln = listNext(&li))) {
         compressionConnection *cc = listNodeValue(ln);
-        if (!connHasReadHandler((connection*)cc)) continue;
+        if (!cc || !connHasReadHandler((connection*)cc)) continue;
 
         cc->handle_pending = 1;
         cc->underlying->read_handler(cc->underlying);
@@ -412,25 +671,12 @@ int RedisRegisterConnectionTypeCompression(void) {
     return connTypeRegister(&CT_Compression);
 }
 
-static void *zlib_alloc_wrapper(void *opaque, unsigned int items,
-                                unsigned int size) {
-    UNUSED(opaque);
-    return zmalloc(items * size);
-}
-
-static void zlib_free_wrapper(void *opaque, void *address) {
-    UNUSED(opaque);
-    zfree(address);
-}
-
 int compressionStateCreate(client *c) {
     compressionState *st = zmalloc(sizeof(compressionState));
-    st->client = c;
-
-    st->zlib.zalloc = zlib_alloc_wrapper;
-    st->zlib.zfree = zlib_free_wrapper;
-
+    st->type = &zstdType;
     st->last_write = 0;
+    st->write_flush_pending = 0;
+    st->read_flush_pending = 0;
     st->dir = CD_INVALID;
 
     c->compression_state = st;
@@ -438,17 +684,12 @@ int compressionStateCreate(client *c) {
     return 1;
 }
 
-#include <stdlib.h>
 void compressionStateDestroy(compressionState *state) {
     if (state == NULL) return;
 
-    if (state->dir == DECOMPRESS) {
-        inflateEnd(&state->zlib);
-    }
-    if (state->dir == COMPRESS) {
-        deflateEnd(&state->zlib);
-    }
-
+    state->type->end(state);
+    zfree(state->input.data);
+    zfree(state->output.data);
     zfree(state);
 }
 
@@ -464,19 +705,10 @@ int clientCreateCompressionState(client *c, compressionDirection dir) {
     if (dir == COMPRESS) {
         serverAssert(c->compression_level > 0 && c->flags & CLIENT_SLAVE);
 
-        if (deflateInit(&st->zlib, c->compression_level) != Z_OK) {
-            serverLog(LL_NOTICE, "Failed to initialize compression: %s", st->zlib.msg);
+        if (st->type->init_compress(st, c->compression_level) == -1) {
             compressionStateDestroy(c->compression_state);
             return 0;
         }
-
-        st->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
-        st->zlib.next_out = st->compressed.data;
-        st->compressed.used = 0;
-
-        st->zlib.avail_in = 0;
-        st->zlib.next_in = st->uncompressed.data;
-        st->uncompressed.used = 0;
 
         st->dir = COMPRESS;
 
@@ -485,20 +717,11 @@ int clientCreateCompressionState(client *c, compressionDirection dir) {
     } else if (dir == DECOMPRESS) {
         serverAssert(server.repl_master_compression_level > 0);
 
-        if (inflateInit(&st->zlib) != Z_OK) {
-            serverLog(LL_NOTICE, "Failed to initialize decompression: %s", st->zlib.msg);
+        if (st->type->init_decompress(st) == -1) {
             compressionStateDestroy(c->compression_state);
             return 0;
         }
-
-        st->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
-        st->zlib.next_out = st->uncompressed.data;
-        st->compressed.used = 0;
-
-        st->zlib.avail_in = 0;
-        st->zlib.next_in = st->compressed.data;
-        st->uncompressed.used = 0;
-
+ 
         st->dir = DECOMPRESS;
 
         serverLog(LL_NOTICE, "Decompression for master client initialized.");
@@ -521,7 +744,7 @@ int clientCreateCompressionState(client *c, compressionDirection dir) {
 void clientDestroyCompressionState(client *c) {
     if (c->compression_state == NULL) return;
 
-    if (c->compression_state->dir == DECOMPRESS && c->conn) {
+    if (c->conn) {
         compressionConnection *cc = (compressionConnection*)c->conn;
         c->conn = cc->underlying;
 
@@ -572,23 +795,20 @@ int compressAndWrite(client *c, int *tot_written) {
 
     /* All available uncompressed data was consumed so we need to reset the
      * uncompressed buffer */
-    if (state->uncompressed.used == ZLIB_TEMP_BUF_SIZE &&
-        state->zlib.avail_in == 0)
+    if (state->input.written == state->input.size &&
+        state->input.consumed == state->input.size)
     {
-        state->uncompressed.used = 0;
-        state->zlib.next_in = state->uncompressed.data;
+        state->input.written = 0;
+        state->input.consumed = 0;
     }
 
-    if (state->zlib.avail_out > 0) {
+    if (state->output.written < state->output.size) {
         /* Force flush after `compression_max_latency` ms have passed.
          * Note, this only makes sense when we have enough space for compressing
          * data. */
         int flush = mstime() - state->last_write > server.compression_max_latency;
         // if (flush) serverLog(LL_NOTICE, "Flushing client %llu", c->id);
-        int err = deflate(&state->zlib, flush ? Z_SYNC_FLUSH : Z_NO_FLUSH);
-        if (err != Z_OK && err != Z_BUF_ERROR) {
-            serverLog(LL_WARNING, "Flush compress error: %s (%d)",
-                      state->zlib.msg, err);
+        if (state->type->compress(state, flush) == -1) {
             clientDestroyCompressionState(c);
             return 1;
         }
@@ -599,36 +819,35 @@ int compressAndWrite(client *c, int *tot_written) {
     /* Try to write all the data available in the compressed buffer. */
     *tot_written = 0;
     int towrite =
-        state->zlib.next_out - (state->compressed.data + state->compressed.used);
-    while (towrite > 0) {
+        state->output.written - state->output.consumed;
+    do {
         int written = connWrite(
-            cc->underlying, state->compressed.data + state->compressed.used, towrite);
+            cc->underlying, state->output.data + state->output.consumed, towrite);
         if (written < 0) {
             return 1;
         }
 
         // if (written > 0) {
         //     char *buf = zmalloc(written + 1);
-        //     memcpy(buf, state->compressed.data+state->compressed.used, written);
+        //     memcpy(buf, state->output.data+state->output.consumed, written);
         //     buf[written] = 0;
-        //     printf("", buf);
+        //     printf("WRITTEN COMPRESSED: %s\n", buf);
         //     zfree(buf);
         // }
 
-        state->compressed.used += written;
+        state->output.consumed += written;
         *tot_written += written;
         towrite -= written;
 
         /* All of the compressed data was send to the socket so we need to reset
          * the compression buffer. */
-        if (state->compressed.used == ZLIB_TEMP_BUF_SIZE) {
-            serverAssert(towrite == 0 && state->zlib.avail_out == 0);
+        if (state->output.consumed == state->output.size) {
+            serverAssert(towrite == 0 && state->output.written == state->output.size);
 
-            state->compressed.used = 0;
-            state->zlib.next_out = state->compressed.data;
-            state->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
+            state->output.written = 0;
+            state->output.consumed = 0;
         }
-    }
+    } while (towrite > 0);
 
     if (*tot_written > 0)
         state->last_write = mstime();
@@ -644,56 +863,53 @@ int decompressInto(compressionState *state, char *buf, size_t buflen) {
 
     /* Decompress as much data as possible */
     while ((size_t)consumed < buflen &&
-           (state->zlib.avail_in > 0 ||
-            state->zlib.next_out > state->uncompressed.data + state->uncompressed.used))
+           (state->read_flush_pending ||
+            state->input.written > state->input.consumed ||
+            state->output.written > state->output.consumed))
     {
         /* Reset the decompressed buffer if all the available data is consumed */
-        if (state->uncompressed.used == ZLIB_TEMP_BUF_SIZE &&
-            state->zlib.avail_out == 0)
-        {
-            state->uncompressed.used = 0;
-            state->zlib.next_out = state->uncompressed.data;
-            state->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
+        if (state->output.consumed == state->output.size) {
+            state->output.written = 0;
+            state->output.consumed = 0;
         }
 
-        if (state->zlib.avail_in > 0) {
-            int err = inflate(&state->zlib, Z_SYNC_FLUSH);
-            if (err != Z_OK && err != Z_BUF_ERROR) {
-                serverLog(LL_NOTICE, "Decompress error: %s (%d)", state->zlib.msg, err);
+        if ((state->read_flush_pending && state->output.size > state->output.written) ||
+            state->input.written > state->input.consumed)
+        {
+            if (state->type->decompress(state) == -1) {
                 return -1;
             }
         }
 
         /* Copy the decompressed data to the output buffer */
-        if (state->zlib.next_out >
-            state->uncompressed.data + state->uncompressed.used)
-        {
-            int avail_decompressed =
-                ZLIB_TEMP_BUF_SIZE - state->zlib.avail_out;
-            int to_consume =
-                min(buflen - consumed,
-                    (size_t)(avail_decompressed - state->uncompressed.used));
-            memcpy(buf + consumed,
-                state->uncompressed.data + state->uncompressed.used, to_consume);
+        if (state->output.written > state->output.consumed) {
+            size_t nonconsumed_decompressed = state->output.written - state->output.consumed;
+            int to_consume = min(buflen - consumed, nonconsumed_decompressed);
+            memcpy(buf + consumed, state->output.data + state->output.consumed, to_consume);
 
             // if (to_consume > 0) {
-            //     char *buf = zmalloc(to_consume + 1);
-            //     memcpy(buf, state->uncompressed.data+state->uncompressed.used, to_consume);
-            //     buf[to_consume] = 0;
-            //     printf("\nDECOMPRESSED: %s\n", buf);
+            //     char *res = zmalloc(to_consume + 1);
+            //     memcpy(res, buf+consumed, to_consume);
+            //     res[to_consume] = 0;
+            //     printf("\nDECOMPRESSED: %s\n", res);
+            //     zfree(res);
             // }
 
-            state->uncompressed.used += to_consume;
+            state->output.consumed += to_consume;
             consumed += to_consume;
         }
     }
 
-    /* Reset the compressed buffer if we decompressed all the available data */
-    if (state->compressed.used == ZLIB_TEMP_BUF_SIZE &&
-        state->zlib.avail_in == 0)
+    if (state->output.consumed == state->output.size)
     {
-        state->compressed.used = 0;
-        state->zlib.next_in = state->compressed.data;
+        state->output.written = 0;
+        state->output.consumed = 0;
+    }
+
+    /* Reset the compressed buffer if we decompressed all the available data */
+    if (state->input.consumed == state->input.size) {
+        state->input.written = 0;
+        state->input.consumed = 0;
     }
 
     serverAssert((size_t)consumed <= buflen);
@@ -719,16 +935,16 @@ int readFromBufAndDecompress(client *c, char *input_buf, size_t input_len,
     *consumed = 0;
     while (*consumed <= input_len && (size_t)tot_decompressed < output_len) {
         int to_consume =
-            min(ZLIB_TEMP_BUF_SIZE - state->compressed.used,
+            min(state->input.size - state->input.written,
                 (int)(input_len - *consumed));
 
         if (to_consume)
-            memcpy(state->compressed.data + state->compressed.used,
+            memcpy(state->input.data + state->input.written,
                    input_buf + *consumed, to_consume);
 
         // if (to_consume > 0) {
         //     char *buf = zmalloc(to_consume + 1);
-        //     memcpy(buf, state->compressed.data+state->compressed.used, to_consume);
+        //     memcpy(buf, state->input.data+state->input.written, to_consume);
         //     buf[to_consume] = 0;
         //     printf("\nNREAD: %s\n", buf);
         //     zfree(buf);
@@ -736,8 +952,7 @@ int readFromBufAndDecompress(client *c, char *input_buf, size_t input_len,
 
         *consumed += to_consume;
 
-        state->compressed.used += to_consume;
-        state->zlib.avail_in += to_consume;
+        state->input.written += to_consume;
 
         int decompressed = decompressInto(state, output_buf + tot_decompressed,
                                           output_len - tot_decompressed);
@@ -754,8 +969,7 @@ int clientHasPendingCompressionFlush(client *c) {
     if (!state) return 0;
     if (state->dir != COMPRESS) return 0;
 
-    // return state->zlib.avail_out > 0 || (state->zlib.next_out - (state->compressed.data + state->compressed.used) > 0);
-    return mstime() - state->last_write >= server.compression_max_latency;
+    return state->write_flush_pending || (mstime() - state->last_write >= server.compression_max_latency);
 }
 
 int clientHasPendingCompressedData(client *c) {
@@ -763,18 +977,8 @@ int clientHasPendingCompressedData(client *c) {
     if (!state) return 0;
     if (state->dir != DECOMPRESS) return 0;
 
-    return state->zlib.avail_in > 0 &&
-           state->zlib.next_out > state->uncompressed.data + state->uncompressed.used;
+    return state->read_flush_pending ||
+           state->input.written > state->input.consumed ||
+           state->output.written > state->output.consumed;
 }
 
-int clientProcessPendingCompressedData(struct client *c) {
-    if (!connHasReadHandler(c->conn)) return 0;
-    if (!clientHasPendingCompressedData(c)) return 0;
-
-    compressionConnection *cc = (compressionConnection*)c->conn;
-    cc->handle_pending = 1;
-    cc->underlying->read_handler(cc->underlying);
-    cc->handle_pending = 0;
-
-    return 1;
-}

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -131,6 +131,10 @@ void clientDestroyCompressionState(client *c) {
               " (slave)" : "");
 }
 
+/* Enable client compression and create compression state if not present.
+ * Currently only valid for primary/replica clients.
+ * Return 0 if compression state was not created and failed to be initialized,
+ * 1 if compression was enabled. */
 int clientEnableCompression(client *c, compressionDirection dir) {
     if (!clientCreateCompressionState(c, dir)) {
         return 0;
@@ -140,15 +144,17 @@ int clientEnableCompression(client *c, compressionDirection dir) {
     return 1;
 }
 
+/* Disable compression without destroying compression state. If compression was
+ * not initialized does nothing. */
 void clientDisableCompression(client *c) {
     c->io_flags &= ~CLIENT_IO_COMPRESSION_ENABLED;
 }
 
-/* Write any available data in the compressed buffer. If compression_max_latency
- * has passed since last write we flush the buffer so we write to the socket
- * ASAP.
- * Return the number of bytes written to socket. Return -1 on socket error.
- * On decompression error the compression state is destroyed and -1 returned. */
+/* Compress any data send for compression by consumeAndTryWriteCompressed and
+ * write to socket. Zlib may not return compressed data immediately so this
+ * call may not write anything to socket.
+ * Force flushes the compressed buffer according to compression_max_latency.
+ * Return number of bytes written to socket or -1 on socket write error. */
 int compressAndWrite(client *c) {
     if (c->compression_level <= 0)
         return 0;
@@ -222,11 +228,13 @@ int compressAndWrite(client *c) {
     return tot_written;
 }
 
-/* Copy the data we need to send to internal buffers, pass to zlib for
- * compression and try to send as much as possible to the socket. Return how
- * much bytes we read from `data` or -1 on zlib error;
- */
-int consumeAndTryWriteCompressed(client *c, char *data, size_t len,
+/* Consume bytes from the `data` buffer, then try to compress and write to the
+ * client's connection. Zlib may not return compressed data immediately so this
+ * call may not write anything to socket.
+ * Return number of bytes consumed from `data`. `nwritten` must be a valid
+ * pointer - it is incremented by the number of bytes written to socket or set
+ * to -1 on socket write error. */
+int consumeAndTryWriteCompressed(client *c, const char *data, size_t len,
                                  ssize_t *nwritten) {
     serverAssert(nwritten);
 
@@ -343,16 +351,24 @@ int decompressInto(client *c, char *buf, size_t buflen) {
     return consumed;
 }
 
-int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *tot_read) {
+/* Read data from client connection and decompress it immediately. The result is
+ * written into buf.
+ * Return number of bytes decompressed. *nread stores number of bytes read from
+ * the socket or -1 on socket read error.
+ * Note, that we may have enough compressed data on the socket that decompressing
+ * it will exceed buflen. To handle decompressed data without readQueryFromClient
+ * being called from a read handler, the readQueryFromClient is called in an
+ * IO-thread cron with the client->flag & CLIENT_IO_READ_DECOMPRESSED_CRON. With
+ * that flag raised we don't read from socket - we only read any available
+ * decompressed data. */
+int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *net_read) {
     compressionState *state = c->compression_state;
-    if (!state) {
-        *tot_read = -1;
-        return -1;
-    }
 
     int tot_decompressed = 0;
-    *tot_read = 0;
 
+    /* Defaulting to -1 since we first try to decompress any available data.
+     * If anything fails -1 indicates we haven't read anything from socket. */
+    *net_read = -1;
     if (c->io_flags & CLIENT_IO_READ_DECOMPRESSED_CRON &&
         (state->zlib.next_out - (state->uncompressed.data + state->uncompressed.used) <= 0))
     {
@@ -362,7 +378,6 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *tot_re
     /* Try to read any available decompressed data */
     int written = decompressInto(c, buf, buflen);
     if (written == -1) {
-        *tot_read = -1;
         return -1;
     }
     tot_decompressed += written;
@@ -375,6 +390,9 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *tot_re
         return tot_decompressed;
     }
 
+    /* Now we start reading from socket so reset to 0 in order to properly count
+     * how many bytes were read. */
+    *net_read = 0;
     do {
         /* Read data from socket and save it inside the compressed buffer */
         int nread =
@@ -382,11 +400,8 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *tot_re
                     ZLIB_TEMP_BUF_SIZE - state->compressed.used);
 
         if (nread <= 0) {
-            if (nread < 0 && c->conn->state == CONN_STATE_ERROR) {
+            if (nread < 0 && connGetState(c->conn) == CONN_STATE_ERROR) {
                 serverLog(LL_NOTICE, "Compressed read error: %s", strerror(errno));
-                clientDestroyCompressionState(c);
-                freeClientAsync(c);
-                *tot_read = -1;
                 return -1;
             }
 
@@ -404,7 +419,7 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *tot_re
 
         state->compressed.used += nread;
         state->zlib.avail_in += nread;
-        *tot_read += nread;
+        *net_read += nread;
 
         int decompressed = decompressInto(c, buf + tot_decompressed,
                                           buflen - tot_decompressed);
@@ -413,12 +428,14 @@ int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *tot_re
         tot_decompressed += decompressed;
     } while ((size_t)tot_decompressed < buflen && state->zlib.avail_in > 0);
 
-    if (*tot_read == 0 && c->conn->state == CONN_STATE_CONNECTED)
-        *tot_read = -1;
+    if (*net_read == 0 && c->conn->state == CONN_STATE_CONNECTED)
+        *net_read = -1;
 
     return tot_decompressed;
 }
 
+/* Same as readFromSocketAndDecompress but reads from `input_buf` instead of
+ * socket. */
 int readFromBufAndDecompress(struct client *c, char *input_buf, size_t input_len,
                              char *output_buf, size_t output_len, size_t *consumed)
 {

--- a/src/client_comp.c
+++ b/src/client_comp.c
@@ -1,0 +1,455 @@
+#include "server.h"
+#include "client_comp.h"
+#include <zlib.h>
+
+#define ZLIB_TEMP_BUF_SIZE 16 * 1024
+
+typedef struct {
+    unsigned char data[ZLIB_TEMP_BUF_SIZE];
+    int used;
+} tempBuf;
+
+struct compressionState {
+    client *client;
+    tempBuf compressed;   /* Buffer holding compressed data */
+    tempBuf uncompressed; /* Buffer holding uncompressed(decompressed) data */
+    z_stream zlib;        /* Zlib state */
+    mstime_t last_write;  /* Time since last write. Used to check if it's time
+                           * to flush the buffer */
+    int inflate_inited;
+    int deflate_inited;
+};
+
+static void *zlib_alloc_wrapper(void *opaque, unsigned int items,
+                                unsigned int size) {
+    UNUSED(opaque);
+    return zmalloc(items * size);
+}
+
+static void zlib_free_wrapper(void *opaque, void *address) {
+    UNUSED(opaque);
+    zfree(address);
+}
+
+int compressionStateCreate(client *c) {
+    compressionState *st = zmalloc(sizeof(compressionState));
+    st->client = c;
+
+    st->zlib.zalloc = zlib_alloc_wrapper;
+    st->zlib.zfree = zlib_free_wrapper;
+
+    st->last_write = 0;
+    st->inflate_inited = st->deflate_inited = 0;
+
+    c->compression_state = st;
+
+    return 1;
+}
+
+#include <stdlib.h>
+void compressionStateDestroy(compressionState *state) {
+    if (state == NULL) return;
+
+    if (state->inflate_inited) {
+        inflateEnd(&state->zlib);
+    }
+    if (state->deflate_inited) {
+        deflateEnd(&state->zlib);
+    }
+
+    zfree(state);
+}
+
+int clientCreateCompressionState(client *c, compressionDirection dir) {
+    /* Client compression already initialized */
+    if (c->compression_state != NULL)
+        return 1;
+
+    serverAssert(compressionStateCreate(c));
+
+    compressionState *st = c->compression_state;
+
+    if (dir == COMPRESS) {
+        serverAssert(c->compression_level > 0 && c->flags & CLIENT_SLAVE);
+
+        if (deflateInit(&st->zlib, c->compression_level) != Z_OK) {
+            serverLog(LL_NOTICE, "Failed to initialize compression: %s", st->zlib.msg);
+            compressionStateDestroy(c->compression_state);
+            return 0;
+        }
+
+        st->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
+        st->zlib.next_out = st->compressed.data;
+        st->compressed.used = 0;
+
+        st->zlib.avail_in = 0;
+        st->zlib.next_in = st->uncompressed.data;
+        st->uncompressed.used = 0;
+
+        st->deflate_inited = 1;
+
+        serverLog(LL_NOTICE, "Initialized compression at level %d for client #%llu...",
+                c->compression_level, (unsigned long long)c->id);
+    } else if (dir == DECOMPRESS) {
+        serverAssert(server.repl_master_compression_level > 0);
+
+        if (inflateInit(&st->zlib) != Z_OK) {
+            serverLog(LL_NOTICE, "Failed to initialize decompression: %s", st->zlib.msg);
+            compressionStateDestroy(c->compression_state);
+            return 0;
+        }
+
+        st->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
+        st->zlib.next_out = st->uncompressed.data;
+        st->compressed.used = 0;
+
+        st->zlib.avail_in = 0;
+        st->zlib.next_in = st->compressed.data;
+        st->uncompressed.used = 0;
+
+        st->inflate_inited = 1;
+
+        serverLog(LL_NOTICE, "Decompression for master client initialized.");
+    } else {
+        serverAssert(0);
+    }
+
+    return 1;
+}
+
+void clientDestroyCompressionState(client *c) {
+    if (c->compression_state == NULL) return;
+
+    compressionStateDestroy(c->compression_state);
+    c->compression_state = NULL;
+    c->compression_level = 0;
+    c->io_flags &= ~CLIENT_IO_COMPRESSION_ENABLED;
+
+    serverLog(LL_NOTICE, "Compression state for client #%llu%s destroyed...",
+              (unsigned long long)c->id,
+              c->flags & CLIENT_MASTER ? " (master)" : c->flags & CLIENT_SLAVE ?
+              " (slave)" : "");
+}
+
+int clientEnableCompression(client *c, compressionDirection dir) {
+    if (!clientCreateCompressionState(c, dir)) {
+        return 0;
+    }
+
+    c->io_flags |= CLIENT_IO_COMPRESSION_ENABLED;
+    return 1;
+}
+
+void clientDisableCompression(client *c) {
+    c->io_flags &= ~CLIENT_IO_COMPRESSION_ENABLED;
+}
+
+/* Write any available data in the compressed buffer. If compression_max_latency
+ * has passed since last write we flush the buffer so we write to the socket
+ * ASAP.
+ * Return the number of bytes written to socket. Return -1 on socket error.
+ * On decompression error the compression state is destroyed and -1 returned. */
+int compressAndWrite(client *c) {
+    if (c->compression_level <= 0)
+        return 0;
+
+    compressionState *state = c->compression_state;
+    serverAssert(state);
+
+    /* All available uncompressed data was consumed so we need to reset the
+     * uncompressed buffer */
+    if (state->uncompressed.used == ZLIB_TEMP_BUF_SIZE &&
+        state->zlib.avail_in == 0)
+    {
+        state->uncompressed.used = 0;
+        state->zlib.next_in = state->uncompressed.data;
+    }
+
+    if (state->zlib.avail_out > 0) {
+        /* Force flush after `compression_max_latency` ms have passed.
+         * Note, this only makes sense when we have enough space for compressing
+         * data. */
+        int flush = mstime() - state->last_write > server.compression_max_latency;
+        // if (flush) serverLog(LL_NOTICE, "Flushing client %llu", c->id);
+        int err = deflate(&state->zlib, flush ? Z_SYNC_FLUSH : Z_NO_FLUSH);
+        if (err != Z_OK && err != Z_BUF_ERROR) {
+            serverLog(LL_WARNING, "Flush compress error: %s (%d)",
+                      state->zlib.msg, err);
+            clientDestroyCompressionState(c);
+            return -1;
+        }
+    }
+
+    /* Try to write all the data available in the compressed buffer. */
+    int tot_written = 0;
+    int towrite =
+        state->zlib.next_out - (state->compressed.data + state->compressed.used);
+    while (towrite > 0) {
+        int written = connWrite(
+            c->conn, state->compressed.data + state->compressed.used, towrite);
+        if (written < 0) {
+            return written;
+        }
+
+        // if (written > 0) {
+        //     char *buf = zmalloc(written + 1);
+        //     memcpy(buf, state->compressed.data+state->compressed.used, written);
+        //     buf[written] = 0;
+        //     printf("\nWRITTEN: %s\n", buf);
+        // }
+
+        if (written > 0) {
+            state->compressed.used += written;
+            tot_written += written;
+            towrite -= written;
+
+        }
+
+        /* All of the compressed data was send to the socket so we need to reset
+         * the compression buffer. */
+        if (state->compressed.used == ZLIB_TEMP_BUF_SIZE) {
+            serverAssert(towrite == 0 && state->zlib.avail_out == 0);
+
+            state->compressed.used = 0;
+            state->zlib.next_out = state->compressed.data;
+            state->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
+        }
+    }
+
+    if (tot_written > 0)
+        state->last_write = mstime();
+
+    return tot_written;
+}
+
+/* Copy the data we need to send to internal buffers, pass to zlib for
+ * compression and try to send as much as possible to the socket. Return how
+ * much bytes we read from `data` or -1 on zlib error;
+ */
+int consumeAndTryWriteCompressed(client *c, char *data, size_t len,
+                                 ssize_t *nwritten) {
+    serverAssert(nwritten);
+
+    compressionState *state = c->compression_state;
+    serverAssert(state);
+
+    int consumed = 0;
+    while ((size_t)consumed != len) {
+        int to_consume =
+            min(ZLIB_TEMP_BUF_SIZE - state->uncompressed.used,
+                (int)(len - consumed));
+
+        memcpy(state->uncompressed.data + state->uncompressed.used,
+               data + consumed, to_consume);
+
+        serverAssert(to_consume >= 0);
+
+        // if (to_consume > 0) {
+        //     char *buf = zmalloc(to_consume + 1);
+        //     memcpy(buf, data+consumed, to_consume);
+        //     buf[to_consume] = 0;
+        //     printf("\nCONSUMED: %s\n", buf);
+        // }
+
+        state->uncompressed.used += to_consume;
+        consumed += to_consume;
+        state->zlib.avail_in += to_consume;
+
+        /* Write whatever we have available in the compressed buffer */
+        int written = compressAndWrite(c);
+        if (written < 0) {
+            if (connGetState(c->conn) != CONN_STATE_CONNECTED) {
+                *nwritten = -1;
+                return -1;
+            }
+            *nwritten = -1;
+            return consumed;
+        }
+        *nwritten += written;
+
+        if (written == 0)
+            break;
+    }
+
+    return consumed;
+}
+
+int decompressInto(client *c, char *buf, size_t buflen) {
+    if (buflen == 0)
+      return 0;
+
+    compressionState *state = c->compression_state;
+    serverAssert(state);
+
+    int consumed = 0;
+
+    /* Decompress as much data as possible */
+    while ((size_t)consumed < buflen &&
+           (state->zlib.avail_in > 0 ||
+            state->zlib.next_out > state->uncompressed.data + state->uncompressed.used))
+    {
+        /* Reset the decompressed buffer if all the available data is consumed */
+        if (state->uncompressed.used == ZLIB_TEMP_BUF_SIZE &&
+            state->zlib.avail_out == 0)
+        {
+            state->uncompressed.used = 0;
+            state->zlib.next_out = state->uncompressed.data;
+            state->zlib.avail_out = ZLIB_TEMP_BUF_SIZE;
+        }
+
+        if (state->zlib.avail_in > 0) {
+            int err = inflate(&state->zlib, Z_SYNC_FLUSH);
+            if (err != Z_OK && err != Z_BUF_ERROR) {
+                serverLog(LL_NOTICE, "Decompress error: %s (%d)", state->zlib.msg, err);
+                clientDestroyCompressionState(c);
+                freeClientAsync(c);
+                return -1;
+            }
+        }
+
+        /* Copy the decompressed data to the output buffer */
+        if (state->zlib.next_out >
+            state->uncompressed.data + state->uncompressed.used)
+        {
+            int avail_decompressed =
+                ZLIB_TEMP_BUF_SIZE - state->zlib.avail_out;
+            int to_consume =
+                min(buflen - consumed,
+                    (size_t)(avail_decompressed - state->uncompressed.used));
+            memcpy(buf + consumed,
+                state->uncompressed.data + state->uncompressed.used, to_consume);
+
+            // if (to_consume > 0) {
+            //     char *buf = zmalloc(to_consume + 1);
+            //     memcpy(buf, state->uncompressed.data+state->uncompressed.used, to_consume);
+            //     buf[to_consume] = 0;
+            //     printf("\nDECOMPRESSED: %s\n", buf);
+            // }
+
+            state->uncompressed.used += to_consume;
+            consumed += to_consume;
+        }
+    }
+
+    /* Reset the compressed buffer if we decompressed all the available data */
+    if (state->compressed.used == ZLIB_TEMP_BUF_SIZE &&
+        state->zlib.avail_in == 0)
+    {
+        state->compressed.used = 0;
+        state->zlib.next_in = state->compressed.data;
+    }
+
+    serverAssert((size_t)consumed <= buflen);
+    return consumed;
+}
+
+int readFromSocketAndDecompress(client *c, char *buf, size_t buflen, int *tot_read) {
+    compressionState *state = c->compression_state;
+    if (!state) {
+        *tot_read = -1;
+        return -1;
+    }
+
+    int tot_decompressed = 0;
+    *tot_read = 0;
+
+    if (c->io_flags & CLIENT_IO_READ_DECOMPRESSED_CRON &&
+        (state->zlib.next_out - (state->uncompressed.data + state->uncompressed.used) <= 0))
+    {
+        return -1;
+    }
+
+    /* Try to read any available decompressed data */
+    int written = decompressInto(c, buf, buflen);
+    if (written == -1) {
+        *tot_read = -1;
+        return -1;
+    }
+    tot_decompressed += written;
+
+    /* In case we are here because a cron function called readQueryFromClient
+     * that means we only need to read any available decompressed data.
+     * We don't try to read from socket in this case as this function is
+     * not handling a read. */
+    if (c->io_flags & CLIENT_IO_READ_DECOMPRESSED_CRON) {
+        return tot_decompressed;
+    }
+
+    do {
+        /* Read data from socket and save it inside the compressed buffer */
+        int nread =
+            connRead(c->conn, state->compressed.data + state->compressed.used,
+                    ZLIB_TEMP_BUF_SIZE - state->compressed.used);
+
+        if (nread <= 0) {
+            if (nread < 0 && c->conn->state == CONN_STATE_ERROR) {
+                serverLog(LL_NOTICE, "Compressed read error: %s", strerror(errno));
+                clientDestroyCompressionState(c);
+                freeClientAsync(c);
+                *tot_read = -1;
+                return -1;
+            }
+
+            /* If no error just continue - we may have some more data to
+             * decompress even if the connection was closed. */
+            nread = 0;
+        }
+
+        // if (nread > 0) {
+        //     char *buf = zmalloc(nread + 1);
+        //     memcpy(buf, state->compressed.data+state->compressed.used, nread);
+        //     buf[nread] = 0;
+        //     printf("\nNREAD: %s\n", buf);
+        // }
+
+        state->compressed.used += nread;
+        state->zlib.avail_in += nread;
+        *tot_read += nread;
+
+        int decompressed = decompressInto(c, buf + tot_decompressed,
+                                          buflen - tot_decompressed);
+        if (decompressed <= 0)
+            break;
+        tot_decompressed += decompressed;
+    } while ((size_t)tot_decompressed < buflen && state->zlib.avail_in > 0);
+
+    if (*tot_read == 0 && c->conn->state == CONN_STATE_CONNECTED)
+        *tot_read = -1;
+
+    return tot_decompressed;
+}
+
+int readFromBufAndDecompress(struct client *c, char *input_buf, size_t input_len,
+                             char *output_buf, size_t output_len, size_t *consumed)
+{
+    compressionState *state = c->compression_state;
+    if (!state) {
+        return -1;
+    }
+
+    int tot_decompressed = 0;
+    *consumed = 0;
+    while (*consumed < input_len && (size_t)tot_decompressed < output_len) {
+        int to_consume =
+            min(ZLIB_TEMP_BUF_SIZE - state->compressed.used,
+                (int)(input_len - *consumed));
+
+        memcpy(state->compressed.data + state->compressed.used,
+               input_buf + *consumed, to_consume);
+
+        *consumed += to_consume;
+
+        state->compressed.used += to_consume;
+        state->zlib.avail_in += to_consume;
+
+        int decompressed = decompressInto(c, output_buf + tot_decompressed,
+                                          output_len - tot_decompressed);
+        if (decompressed <= 0)
+            break;
+        tot_decompressed += decompressed;
+    }
+
+    return tot_decompressed;
+
+}
+

--- a/src/client_comp.h
+++ b/src/client_comp.h
@@ -39,6 +39,4 @@ int readFromBufAndDecompress(struct client *c, char *input_buf, size_t input_len
 int clientHasPendingCompressionFlush(struct client *c);
 int clientHasPendingCompressedData(struct client *c);
 
-int clientProcessPendingCompressedData(struct client *c);
-
 #endif /* __CLIENT_COMP_H */

--- a/src/client_comp.h
+++ b/src/client_comp.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of (a) the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#ifndef __CLIENT_COMP_H
+#define __CLIENT_COMP_H
+
+#include <sys/types.h>
+
+/* Opaque handle to client's compression state used internally by client_comp */
+typedef struct compressionState compressionState;
+
+struct client;
+
+typedef enum {
+    COMPRESS,
+    DECOMPRESS,
+} compressionDirection;
+
+int clientCreateCompressionState(struct client *c, compressionDirection dir);
+void clientDestroyCompressionState(struct client *c);
+
+/* Enable client compression and create compression state if not present.
+ * Currently only valid for primary/replica clients.
+ * Return 0 if compression state was not created and failed to be initialized,
+ * 1 if compression was enabled. */
+int clientEnableCompression(struct client *c, compressionDirection dir);
+
+/* Disable compression without destroying compression state. If compression was
+ * not initialized does nothing. */
+void clientDisableCompression(struct client *c);
+
+/* Compress any data send for compression by consumeAndTryWriteCompressed and
+ * write to socket. Zlib may not return compressed data immediately so this
+ * call may not write anything to socket.
+ * Force flushes the compressed buffer according to compression_max_latency.
+ * Return number of bytes written to socket or -1 on socket write error. */
+int compressAndWrite(struct client *c);
+
+/* Consume bytes from the `data` buffer, then try to compress and write to the
+ * client's connection. Zlib may not return compressed data immediately so this
+ * call may not write anything to socket.
+ * Return number of bytes consumed from `data`. `nwritten` must be a valid
+ * pointer - it is incremented by the number of bytes written to socket or set
+ * to -1 on socket write error. */
+int consumeAndTryWriteCompressed(struct client *c, char *data, size_t len,
+                                 ssize_t *nwritten);
+
+/* Read data from client connection and decompress it immediately. The result is
+ * written into buf.
+ * Return number of bytes decompressed. *nread stores number of bytes read from
+ * the socket or -1 on socket read error.
+ * Note, that we may have enough compressed data on the socket that decompressing
+ * it will exceed buflen. To handle decompressed data without readQueryFromClient
+ * being called from a read handler, the readQueryFromClient is called in an
+ * IO-thread cron with the client->flag & CLIENT_IO_READ_DECOMPRESSED_CRON. With
+ * that flag raised we don't read from socket - we only read any available
+ * decompressed data. */
+int readFromSocketAndDecompress(struct client *c, char *buf, size_t buflen,
+                                int *nread);
+
+/* Same as readFromSocketAndDecompress but reads from `input_buf` instead of
+ * socket. */
+int readFromBufAndDecompress(struct client *c, char *input_buf, size_t input_len,
+                             char *output_buf, size_t output_len,
+                             size_t *consumed);
+
+#endif /* __CLIENT_COMP_H */

--- a/src/client_comp.h
+++ b/src/client_comp.h
@@ -41,4 +41,7 @@ int readFromBufAndDecompress(struct client *c, char *input_buf, size_t input_len
                              char *output_buf, size_t output_len,
                              size_t *consumed);
 
+int clientHasPendingCompressionFlush(struct client *c);
+int clientHasPendingCompressedData(struct client *c);
+
 #endif /* __CLIENT_COMP_H */

--- a/src/client_comp.h
+++ b/src/client_comp.h
@@ -25,47 +25,18 @@ typedef enum {
 int clientCreateCompressionState(struct client *c, compressionDirection dir);
 void clientDestroyCompressionState(struct client *c);
 
-/* Enable client compression and create compression state if not present.
- * Currently only valid for primary/replica clients.
- * Return 0 if compression state was not created and failed to be initialized,
- * 1 if compression was enabled. */
 int clientEnableCompression(struct client *c, compressionDirection dir);
 
-/* Disable compression without destroying compression state. If compression was
- * not initialized does nothing. */
 void clientDisableCompression(struct client *c);
 
-/* Compress any data send for compression by consumeAndTryWriteCompressed and
- * write to socket. Zlib may not return compressed data immediately so this
- * call may not write anything to socket.
- * Force flushes the compressed buffer according to compression_max_latency.
- * Return number of bytes written to socket or -1 on socket write error. */
 int compressAndWrite(struct client *c);
 
-/* Consume bytes from the `data` buffer, then try to compress and write to the
- * client's connection. Zlib may not return compressed data immediately so this
- * call may not write anything to socket.
- * Return number of bytes consumed from `data`. `nwritten` must be a valid
- * pointer - it is incremented by the number of bytes written to socket or set
- * to -1 on socket write error. */
-int consumeAndTryWriteCompressed(struct client *c, char *data, size_t len,
+int consumeAndTryWriteCompressed(struct client *c, const char *data, size_t len,
                                  ssize_t *nwritten);
 
-/* Read data from client connection and decompress it immediately. The result is
- * written into buf.
- * Return number of bytes decompressed. *nread stores number of bytes read from
- * the socket or -1 on socket read error.
- * Note, that we may have enough compressed data on the socket that decompressing
- * it will exceed buflen. To handle decompressed data without readQueryFromClient
- * being called from a read handler, the readQueryFromClient is called in an
- * IO-thread cron with the client->flag & CLIENT_IO_READ_DECOMPRESSED_CRON. With
- * that flag raised we don't read from socket - we only read any available
- * decompressed data. */
 int readFromSocketAndDecompress(struct client *c, char *buf, size_t buflen,
                                 int *nread);
 
-/* Same as readFromSocketAndDecompress but reads from `input_buf` instead of
- * socket. */
 int readFromBufAndDecompress(struct client *c, char *input_buf, size_t input_len,
                              char *output_buf, size_t output_len,
                              size_t *consumed);

--- a/src/client_comp.h
+++ b/src/client_comp.h
@@ -30,13 +30,7 @@ int clientEnableCompression(struct client *c, compressionDirection dir);
 
 void clientDisableCompression(struct client *c);
 
-int compressAndWrite(struct client *c);
-
-int consumeAndTryWriteCompressed(struct client *c, const char *data, size_t len,
-                                 ssize_t *nwritten);
-
-int readFromSocketAndDecompress(struct client *c, char *buf, size_t buflen,
-                                int *nread);
+int compressAndWrite(struct client *c, int *tot_written);
 
 int readFromBufAndDecompress(struct client *c, char *input_buf, size_t input_len,
                              char *output_buf, size_t output_len,

--- a/src/client_comp.h
+++ b/src/client_comp.h
@@ -18,6 +18,7 @@ typedef struct compressionState compressionState;
 struct client;
 
 typedef enum {
+    CD_INVALID,
     COMPRESS,
     DECOMPRESS,
 } compressionDirection;
@@ -43,5 +44,7 @@ int readFromBufAndDecompress(struct client *c, char *input_buf, size_t input_len
 
 int clientHasPendingCompressionFlush(struct client *c);
 int clientHasPendingCompressedData(struct client *c);
+
+int clientProcessPendingCompressedData(struct client *c);
 
 #endif /* __CLIENT_COMP_H */

--- a/src/cluster_asm.c
+++ b/src/cluster_asm.c
@@ -1316,7 +1316,7 @@ void asmRdbChannelSyncWithSource(connection *conn) {
          * surface the error condition.
          * using shutdown() instead of connShutdown() because connTLSShutdown()
          * will free the connection directly, which is not what we want. */
-        shutdown(conn->fd, SHUT_RDWR);
+        shutdown(connGetFd(conn), SHUT_RDWR);
         connRead(conn, buf, 1);
     }
 
@@ -1467,7 +1467,7 @@ void asmSyncWithSource(connection *conn) {
     /* Check if the fail point is active for this channel and state */
     if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state))) {
         char buf[1];
-        shutdown(conn->fd, SHUT_RDWR);
+        shutdown(connGetFd(conn), SHUT_RDWR);
         connRead(conn, buf, 1);
     }
 
@@ -1631,7 +1631,7 @@ void asmSlotSnapshotAndStreamStart(struct asmTask *task) {
     if (task == NULL || task->state != ASM_WAIT_BGSAVE_START) return;
 
     if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_RDB_CHANNEL, task->state))) {
-        shutdown(task->rdb_channel_client->conn->fd, SHUT_RDWR);
+        shutdown(connGetFd(task->rdb_channel_client->conn), SHUT_RDWR);
         return;
     }
     task->main_channel_client->replstate = SLAVE_STATE_SEND_BULK_AND_STREAM;
@@ -2379,7 +2379,7 @@ static void asmSyncBufferReadFromConn(connection *conn) {
 
     /* ASM_ACCUMULATE_BUF and ASM_STREAMING_BUF fail points are handled here */
     if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state)))
-        shutdown(conn->fd, SHUT_RDWR);
+        shutdown(connGetFd(conn), SHUT_RDWR);
 
     replDataBuf *buf = &task->sync_buffer;
     if (task->state == ASM_STREAMING_BUF) {
@@ -2481,7 +2481,7 @@ void asmSyncBufferStreamToDb(asmTask *task) {
                              task->dest_offset);
 
         if (unlikely(asmDebugIsFailPointActive(ASM_IMPORT_MAIN_CHANNEL, task->state)))
-            shutdown(task->main_channel_conn->fd, SHUT_RDWR); /* Simulate a failure */
+            shutdown(connGetFd(task->main_channel_conn), SHUT_RDWR); /* Simulate a failure */
 
         /* ACK offset after streaming buffer is done. */
         asmImportSendACK(task);
@@ -2507,7 +2507,7 @@ void asmSendStreamEofIfDrained(asmTask *task) {
         serverLog(LL_NOTICE, "Slot migration command stream drained, sending STREAM-EOF to the destination");
 
         if (unlikely(asmDebugIsFailPointActive(ASM_MIGRATE_MAIN_CHANNEL, task->state)))
-            shutdown(c->conn->fd, SHUT_RDWR);
+            shutdown(connGetFd(c->conn), SHUT_RDWR);
 
         /* Send STREAM-EOF to indicate the end of the stream. */
         char *err = sendCommand(c->conn, "CLUSTER", "SYNCSLOTS", "STREAM-EOF", NULL);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1221,7 +1221,7 @@ void setClusterNodeToInboundClusterLink(clusterNode *node, clusterLink *link) {
          * one of the links. The existing link is more likely the outdated one, but it's
          * possible the other node may need to open another link. */
         serverLog(LL_DEBUG, "Replacing inbound link fd %d from node %.40s with fd %d",
-                node->inbound_link->conn->fd, node->name, link->conn->fd);
+                connGetFd(node->inbound_link->conn), node->name, connGetFd(link->conn));
         freeClusterLink(node->inbound_link);
     }
     serverAssert(!node->inbound_link);

--- a/src/config.c
+++ b/src/config.c
@@ -3224,6 +3224,8 @@ standardConfig static_configs[] = {
     createIntConfig("cluster-compatibility-sample-ratio", NULL, MODIFIABLE_CONFIG, 0, 100, server.cluster_compatibility_sample_ratio, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-slot-migration-max-archived-tasks", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1, INT_MAX, server.asm_max_archived_tasks, 32, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("lookahead", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.lookahead, REDIS_DEFAULT_LOOKAHEAD, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("repl-compression", NULL, MODIFIABLE_CONFIG, 0, 9, server.repl_compression, 0, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("compression-max-latency", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.compression_max_latency, 100, INTEGER_CONFIG, NULL, NULL), /* 100ms */
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/config.c
+++ b/src/config.c
@@ -3224,7 +3224,7 @@ standardConfig static_configs[] = {
     createIntConfig("cluster-compatibility-sample-ratio", NULL, MODIFIABLE_CONFIG, 0, 100, server.cluster_compatibility_sample_ratio, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-slot-migration-max-archived-tasks", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1, INT_MAX, server.asm_max_archived_tasks, 32, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("lookahead", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.lookahead, REDIS_DEFAULT_LOOKAHEAD, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("repl-compression", NULL, MODIFIABLE_CONFIG, 0, 9, server.repl_compression, 0, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("repl-compression", NULL, MODIFIABLE_CONFIG, 0, 22, server.repl_compression, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("compression-max-latency", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.compression_max_latency, 100, INTEGER_CONFIG, NULL, NULL), /* 100ms */
 
     /* Unsigned int configs */

--- a/src/connection.c
+++ b/src/connection.c
@@ -68,6 +68,8 @@ int connTypeInitialize(void) {
     /* may fail if without BUILD_TLS=yes */
     RedisRegisterConnectionTypeTLS();
 
+    RedisRegisterConnectionTypeCompression();
+
     return C_OK;
 }
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -83,6 +83,7 @@ typedef struct ConnectionType {
     ssize_t (*sync_read)(struct connection *conn, char *ptr, ssize_t size, long long timeout);
     ssize_t (*sync_readline)(struct connection *conn, char *ptr, ssize_t size, long long timeout);
     size_t (*get_last_read)(struct connection *conn);
+    size_t (*get_last_written)(struct connection *conn);
 
     /* event loop */
     void (*unbind_event_loop)(struct connection *conn);
@@ -275,6 +276,14 @@ static inline ssize_t connSyncReadLine(connection *conn, char *ptr, ssize_t size
 static inline int connCheckLastRead(connection *conn, size_t *last_read) {
     if (!conn->type->get_last_read) return 0;
     *last_read = conn->type->get_last_read(conn);
+    return 1;
+}
+
+/* If connection type has a special way to get last written bytes to connection
+ * save the value in last_written and return 1. Otherwise return 0. */
+static inline int connCheckLastWritten(connection *conn, size_t *last_written) {
+    if (!conn->type->get_last_written) return 0;
+    *last_written = conn->type->get_last_written(conn);
     return 1;
 }
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -40,6 +40,7 @@ typedef enum {
 #define CONN_TYPE_SOCKET            "tcp"
 #define CONN_TYPE_UNIX              "unix"
 #define CONN_TYPE_TLS               "tls"
+#define CONN_TYPE_COMPRESSION       "compression"
 #define CONN_TYPE_MAX               8           /* 8 is enough to be extendable */
 
 typedef void (*ConnectionCallbackFunc)(struct connection *conn);
@@ -81,6 +82,7 @@ typedef struct ConnectionType {
     ssize_t (*sync_write)(struct connection *conn, char *ptr, ssize_t size, long long timeout);
     ssize_t (*sync_read)(struct connection *conn, char *ptr, ssize_t size, long long timeout);
     ssize_t (*sync_readline)(struct connection *conn, char *ptr, ssize_t size, long long timeout);
+    size_t (*get_last_read)(struct connection *conn);
 
     /* event loop */
     void (*unbind_event_loop)(struct connection *conn);
@@ -95,6 +97,17 @@ typedef struct ConnectionType {
 
     /* Get peer username based on connection type */
     sds (*get_peer_username)(connection *conn);
+
+    aeEventLoop* (*get_event_loop)(connection *conn);
+    void (*unset_event_loop)(connection *conn);
+    int (*get_fd)(connection *conn);
+    int (*get_iovcnt)(connection *conn);
+    int (*get_state)(connection *conn);
+    int (*get_last_errno)(connection *conn);
+    int (*has_read_handler)(connection *conn);
+    int (*has_write_handler)(connection *conn);
+    void (*set_private_data)(connection *conn, void *data);
+    void* (*get_private_data)(connection *conn);
 } ConnectionType;
 
 struct connection {
@@ -257,13 +270,22 @@ static inline ssize_t connSyncReadLine(connection *conn, char *ptr, ssize_t size
     return conn->type->sync_readline(conn, ptr, size, timeout);
 }
 
+/* If connection type has a special way to get last read bytes from connection
+ * save the value in last_read and return 1. Otherwise return 0. */
+static inline int connCheckLastRead(connection *conn, size_t *last_read) {
+    if (!conn->type->get_last_read) return 0;
+    *last_read = conn->type->get_last_read(conn);
+    return 1;
+}
+
 /* Return CONN_TYPE_* for the specified connection */
 static inline const char *connGetType(connection *conn) {
     return conn->type->get_type(conn);
 }
 
 static inline int connLastErrorRetryable(connection *conn) {
-    return conn->last_errno == EINTR;
+    int last_errno = conn->type->get_last_errno ? conn->type->get_last_errno(conn) : conn->last_errno;
+    return last_errno == EINTR;
 }
 
 /* Get address information of a connection.
@@ -315,33 +337,51 @@ static inline int connIsLocal(connection *conn) {
 }
 
 static inline int connGetState(connection *conn) {
-    return conn->state;
+    return conn->type->get_state ? conn->type->get_state(conn) : conn->state;
+}
+
+static inline int connGetFd(connection *conn) {
+    return conn->type->get_fd ? conn->type->get_fd(conn) : conn->fd;
+}
+
+static inline int connGetIovcnt(connection *conn) {
+    return conn->type->get_iovcnt ? conn->type->get_iovcnt(conn) : conn->iovcnt;
 }
 
 /* Returns true if a write handler is registered */
 static inline int connHasWriteHandler(connection *conn) {
-    return conn->write_handler != NULL;
+    return conn->type->has_write_handler ?
+           conn->type->has_write_handler(conn) :
+           (conn->write_handler != NULL);
 }
 
 /* Returns true if a read handler is registered */
 static inline int connHasReadHandler(connection *conn) {
-    return conn->read_handler != NULL;
+    return conn->type->has_read_handler ?
+           conn->type->has_read_handler(conn) :
+           (conn->read_handler != NULL);
 }
 
 /* Returns true if the connection is bound to an event loop */
 static inline int connHasEventLoop(connection *conn) {
-    return conn->el != NULL;
+    return conn->type->get_event_loop ?
+           (conn->type->get_event_loop(conn) != NULL) :
+           (conn->el != NULL);
 }
 
 /* Unbind the current event loop from the connection, so that it can be
  * rebind to a different event loop in the future. */
 static inline void connUnbindEventLoop(connection *conn) {
-    if (conn->el == NULL) return;
+    if (!connHasEventLoop(conn)) return;
     connSetReadHandler(conn, NULL);
     connSetWriteHandler(conn, NULL);
     if (conn->type->unbind_event_loop)
         conn->type->unbind_event_loop(conn);
-    conn->el = NULL;
+
+    if (conn->type->unset_event_loop)
+        conn->type->unset_event_loop(conn);
+    else
+        conn->el = NULL;
 }
 
 /* Rebind the connection to another event loop, read/write handlers must not
@@ -352,12 +392,17 @@ static inline int connRebindEventLoop(connection *conn, aeEventLoop *el) {
 
 /* Associate a private data pointer with the connection */
 static inline void connSetPrivateData(connection *conn, void *data) {
-    conn->private_data = data;
+    if (conn->type->set_private_data)
+        conn->type->set_private_data(conn, data);
+    else
+        conn->private_data = data;
 }
 
 /* Get the associated private data pointer */
 static inline void *connGetPrivateData(connection *conn) {
-    return conn->private_data;
+    return conn->type->get_private_data ?
+           conn->type->get_private_data(conn) :
+           conn->private_data;
 }
 
 /* Return a text that describes the connection, suitable for inclusion
@@ -366,7 +411,8 @@ static inline void *connGetPrivateData(connection *conn) {
  * For sockets, we always return "fd=<fdnum>" to maintain compatibility.
  */
 static inline const char *connGetInfo(connection *conn, char *buf, size_t buf_len) {
-    snprintf(buf, buf_len-1, "fd=%i", conn == NULL ? -1 : conn->fd);
+    int fd = conn ? connGetFd(conn) : -1;
+    snprintf(buf, buf_len-1, "fd=%i", conn == NULL ? -1 : fd);
     return buf;
 }
 
@@ -462,6 +508,7 @@ sds getListensInfoString(sds info);
 int RedisRegisterConnectionTypeSocket(void);
 int RedisRegisterConnectionTypeUnix(void);
 int RedisRegisterConnectionTypeTLS(void);
+int RedisRegisterConnectionTypeCompression(void);
 
 /* Return 1 if connection is using TLS protocol, 0 if otherwise. */
 static inline int connIsTLS(connection *conn) {

--- a/src/connection.h
+++ b/src/connection.h
@@ -103,7 +103,7 @@ typedef struct ConnectionType {
     void (*unset_event_loop)(connection *conn);
     int (*get_fd)(connection *conn);
     int (*get_iovcnt)(connection *conn);
-    int (*get_state)(connection *conn);
+    ConnectionState (*get_state)(connection *conn);
     int (*get_last_errno)(connection *conn);
     int (*has_read_handler)(connection *conn);
     int (*has_write_handler)(connection *conn);
@@ -345,7 +345,7 @@ static inline int connIsLocal(connection *conn) {
     return -1;
 }
 
-static inline int connGetState(connection *conn) {
+static inline ConnectionState connGetState(connection *conn) {
     return conn->type->get_state ? conn->type->get_state(conn) : conn->state;
 }
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -272,7 +272,10 @@ static inline ssize_t connSyncReadLine(connection *conn, char *ptr, ssize_t size
 }
 
 /* If connection type has a special way to get last read bytes from connection
- * save the value in last_read and return 1. Otherwise return 0. */
+ * save the value in last_read and return 1. Otherwise return 0.
+ * F.e when compression is enabled we read compressed data from socket inside
+ * connRead but it returns the number of bytes decompressed. In order to get the
+ * number of bytes read from socket we call connCheckLastRead. */
 static inline int connCheckLastRead(connection *conn, size_t *last_read) {
     if (!conn->type->get_last_read) return 0;
     *last_read = conn->type->get_last_read(conn);

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -888,7 +888,9 @@ void IOThreadCompressionCron(IOThread *t) {
     listRewind(t->compression_clients, &li);
     /* TODO: if compression is generalized for all types of clients this cron
      * will need to only process a portion of the clients (similar to
-     * IOThreadClientsCron) for performance reasons */
+     * IOThreadClientsCron) for performance reasons. I.e in such case the
+     * clientHasPendingCompressionFlush check may be moved directly to
+     * IOThreadClientsCron. */
     while ((ln = listNext(&li))) {
         client *c = listNodeValue(ln);
 

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -817,32 +817,14 @@ int processClientsFromMainThread(IOThread *t) {
     return processed;
 }
 
-int IOThreadProcessPendingCompressedData(IOThread *t) {
-    int still_has_pending = 0;
-    listIter li;
-    listNode *ln;
-    listRewind(t->compression_clients, &li);
-    while ((ln = listNext(&li))) {
-        client *c = listNodeValue(ln);
-        if (c->io_flags & CLIENT_IO_CLOSE_ASAP) continue;
-        serverAssert(c->compression_state);
-        clientProcessPendingCompressedData(c);
-        still_has_pending += clientHasPendingCompressedData(c);
-    }
-
-    return !!still_has_pending;
-}
-
 void IOThreadBeforeSleep(struct aeEventLoop *el) {
     IOThread *t = el->privdata[0];
 
     /* Handle pending data(typical TLS). */
     connTypeProcessPendingData(el);
 
-    int has_pending_compressed = IOThreadProcessPendingCompressedData(t);
-
     /* If any connection type(typical TLS) still has pending unread data don't sleep at all. */
-    int dont_sleep = connTypeHasPendingData(el) || has_pending_compressed;
+    int dont_sleep = connTypeHasPendingData(el);
 
     /* Process clients from main thread, since the main thread may deliver clients
      * without notification during IO thread processing events. */
@@ -918,22 +900,18 @@ void IOThreadCompressionCron(IOThread *t) {
             /* Only master/replica clients support client compression for now. */
             serverAssert(c->flags & CLIENT_SLAVE);
 
-            int nwritten = compressAndWrite(c);
-            if (nwritten < 0) {
+            int written = 0;
+            int err = compressAndWrite(c, &written);
+            if (err) {
                 if (connGetState(c->conn) != CONN_STATE_CONNECTED)
                     freeClientAsync(c);
                 continue;
             }
 
-            if (nwritten > 0) {
-                c->net_output_bytes += nwritten;
-                atomicIncr(server.stat_net_repl_output_bytes, nwritten);
+            if (written > 0) {
+                c->net_output_bytes += written;
+                atomicIncr(server.stat_net_repl_output_bytes, written);
             }
-        } else if (clientHasPendingCompressedData(c)) {
-            /* We will do that in beforeSleep but since we are already iterating
-             * on t->compression_clients we take advantage of that to also
-             * process pending data here. */
-            clientProcessPendingCompressedData(c);
         }
     }
 }

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -10,9 +10,11 @@
 
 #include "server.h"
 
+#define IO_DEFAULT_HZ CONFIG_DEFAULT_HZ
+
 /* Replicates the behaviour of run_with_period used in serverCron but for
  * IO threads. IO threads use default Hz for now. */
-#define run_with_period_io(_t_, _ms_) _run_with_period((_t_)->cronloops, (_ms_), CONFIG_DEFAULT_HZ)
+#define run_with_period_io(_t_, _ms_) _run_with_period((_t_)->cronloops, (_ms_), IO_DEFAULT_HZ)
 
 /* IO threads. */
 static IOThread IOThreads[IO_THREADS_MAX_NUM];
@@ -864,7 +866,7 @@ void IOThreadClientsCron(IOThread *t) {
     /* Process at least a few clients while we are at it, even if we need
      * to process less than CLIENTS_CRON_MIN_ITERATIONS to meet our contract
      * of processing each client once per second. */
-    int iterations = listLength(t->clients) / CONFIG_DEFAULT_HZ;
+    int iterations = listLength(t->clients) / IO_DEFAULT_HZ;
     if (iterations < CLIENTS_CRON_MIN_ITERATIONS) {
         iterations = CLIENTS_CRON_MIN_ITERATIONS;
     }
@@ -921,7 +923,7 @@ void IOThreadCompressionCron(IOThread *t) {
     }
 }
 
-/* This is the IO thread timer interrupt, CONFIG_DEFAULT_HZ times per second.
+/* This is the IO thread timer interrupt, IO_DEFAULT_HZ times per second.
  * The current responsibility is to detect clients that have been stuck in the
  * IO thread for too long and hand them over to the main thread for handling. */
 int IOThreadCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
@@ -934,7 +936,7 @@ int IOThreadCron(struct aeEventLoop *eventLoop, long long id, void *clientData) 
     /* Run cron tasks for the clients in the IO thread. */
     IOThreadClientsCron(t);
 
-    return 1000/CONFIG_DEFAULT_HZ;
+    return 1000/IO_DEFAULT_HZ;
 }
 
 /* The main function of IO thread, it will run an event loop. The mian thread

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -817,14 +817,32 @@ int processClientsFromMainThread(IOThread *t) {
     return processed;
 }
 
+int IOThreadProcessPendingCompressedData(IOThread *t) {
+    int still_has_pending = 0;
+    listIter li;
+    listNode *ln;
+    listRewind(t->compression_clients, &li);
+    while ((ln = listNext(&li))) {
+        client *c = listNodeValue(ln);
+        if (c->io_flags & CLIENT_IO_CLOSE_ASAP) continue;
+        serverAssert(c->compression_state);
+        clientProcessPendingCompressedData(c);
+        still_has_pending += clientHasPendingCompressedData(c);
+    }
+
+    return !!still_has_pending;
+}
+
 void IOThreadBeforeSleep(struct aeEventLoop *el) {
     IOThread *t = el->privdata[0];
 
     /* Handle pending data(typical TLS). */
     connTypeProcessPendingData(el);
 
+    int has_pending_compressed = IOThreadProcessPendingCompressedData(t);
+
     /* If any connection type(typical TLS) still has pending unread data don't sleep at all. */
-    int dont_sleep = connTypeHasPendingData(el);
+    int dont_sleep = connTypeHasPendingData(el) || has_pending_compressed;
 
     /* Process clients from main thread, since the main thread may deliver clients
      * without notification during IO thread processing events. */
@@ -912,11 +930,10 @@ void IOThreadCompressionCron(IOThread *t) {
                 atomicIncr(server.stat_net_repl_output_bytes, nwritten);
             }
         } else if (clientHasPendingCompressedData(c)) {
-            /* Only master/replica clients support client compression for now. */
-            serverAssert(c->flags & CLIENT_MASTER);
-            c->io_flags |= CLIENT_IO_READ_DECOMPRESSED_CRON;
-            readQueryFromClient(c->conn);
-            c->io_flags &= ~CLIENT_IO_READ_DECOMPRESSED_CRON;
+            /* We will do that in beforeSleep but since we are already iterating
+             * on t->compression_clients we take advantage of that to also
+             * process pending data here. */
+            clientProcessPendingCompressedData(c);
         }
     }
 }

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -10,6 +10,10 @@
 
 #include "server.h"
 
+/* Replicates the behaviour of run_with_period used in serverCron but for
+ * IO threads. IO threads use default Hz for now. */
+#define run_with_period_io(_t_, _ms_) _run_with_period((_t_)->cronloops, (_ms_), CONFIG_DEFAULT_HZ)
+
 /* IO threads. */
 static IOThread IOThreads[IO_THREADS_MAX_NUM];
 
@@ -124,6 +128,13 @@ void enqueuePendingClientsToMainThread(client *c, int unbind) {
         listUnlinkNode(t->clients, c->io_thread_client_list_node);
         listLinkNodeTail(t->pending_clients_to_main_thread, c->io_thread_client_list_node);
         c->io_thread_client_list_node = NULL;
+
+        if (listSearchKey(t->compression_clients, c) ==
+            &c->io_thread_compression_clients_node)
+        {
+            listUnlinkNode(t->compression_clients,
+                           &c->io_thread_compression_clients_node);
+        }
     }
 }
 
@@ -149,6 +160,17 @@ void enqueuePendingClienstToIOThreads(client *c) {
         c->io_lastinteraction = c->lastinteraction;
     }
 
+    /* Check here prevents data races with IO thread which may also check
+     * this flag. */
+    if (!(c->io_flags & CLIENT_IO_COMPRESSION_ENABLED)) {
+        if (c->compression_level > 0) {
+            clientEnableCompression(c, COMPRESS);
+        }
+        if (c->flags & CLIENT_MASTER && server.repl_master_compression_level > 0) {
+            clientEnableCompression(c, DECOMPRESS);
+        }
+    }
+
     c->running_tid = c->tid;
     listAddNodeHead(mainThreadPendingClientsToIOThreads[c->tid], c);
 }
@@ -158,10 +180,24 @@ void enqueuePendingClienstToIOThreads(client *c) {
 void unbindClientFromIOThreadEventLoop(client *c) {
     serverAssert(c->tid != IOTHREAD_MAIN_THREAD_ID &&
                  c->running_tid == IOTHREAD_MAIN_THREAD_ID);
-    if (!connHasEventLoop(c->conn)) return;
+    /* If the client is not bound to an event loop there is nothing to do,
+     * unless the client uses repl compression in which case we need to unlink
+     * it from IO Thread compression_clients list. */
+    if (!connHasEventLoop(c->conn) && !c->compression_state) return;
+
     /* As calling in main thread, we should pause the io thread to make it safe. */
     pauseIOThread(c->tid);
     connUnbindEventLoop(c->conn);
+    IOThread *t = &IOThreads[c->tid];
+    /* We need to remove the client from the compression_clients list so it
+     * won't be processed in IOThreadCompressionCron anymore */
+    if (listSearchKey(t->compression_clients, c) ==
+        &c->io_thread_compression_clients_node)
+    {
+        listUnlinkNode(t->compression_clients,
+                       &c->io_thread_compression_clients_node);
+        clientDisableCompression(c);
+    }
     resumeIOThread(c->tid);
 }
 
@@ -273,7 +309,8 @@ int isClientMustHandledByMainThread(client *c) {
         return 0;
     }
 
-    if (c->flags & (CLIENT_MASTER | CLIENT_SLAVE)) return 1;
+    if (c->flags & (CLIENT_MASTER | CLIENT_SLAVE))
+        return 1;
 
     return 0;
 }
@@ -759,6 +796,14 @@ int processClientsFromMainThread(IOThread *t) {
             connSetReadHandler(c->conn, readQueryFromClient);
         }
 
+        /* Add the client to the compression clients list. */
+        if (c->compression_state != NULL &&
+            listSearchKey(t->compression_clients, c) == NULL)
+        {
+            listLinkNodeTail(t->compression_clients,
+                             &c->io_thread_compression_clients_node);
+        }
+
         /* If the client has pending replies, write replies to client. */
         if (clientHasPendingReplies(c)) {
             writeToClient(c, 0);
@@ -835,6 +880,45 @@ void IOThreadClientsCron(IOThread *t) {
     }
 }
 
+void IOThreadCompressionCron(IOThread *t) {
+    if (listLength(t->compression_clients) == 0) return;
+
+    listIter li;
+    listNode *ln;
+    listRewind(t->compression_clients, &li);
+    while ((ln = listNext(&li))) {
+        client *c = listNodeValue(ln);
+
+        if (c->io_flags & CLIENT_IO_CLOSE_ASAP) continue;
+        serverAssert(c->compression_state);
+
+        /* Usually writeCompressed will be called at the end of compressAndWrite
+         * but when compression maximum latency ms have passed we want to force
+         * flush to the compression buffer so we don't have much delays between
+         * writes to the socket */
+        if (c->flags & CLIENT_SLAVE) {
+            int nwritten = compressAndWrite(c);
+            if (nwritten < 0) {
+                if (connGetState(c->conn) != CONN_STATE_CONNECTED)
+                    freeClientAsync(c);
+                continue;
+            }
+
+            if (nwritten > 0) {
+                c->net_output_bytes += nwritten;
+                atomicIncr(server.stat_net_repl_output_bytes, nwritten);
+            }
+        } else {
+            /* Only master/replica clients support client compression for now. */
+            serverAssert(c->flags & CLIENT_MASTER);
+
+            c->io_flags |= CLIENT_IO_READ_DECOMPRESSED_CRON;
+            readQueryFromClient(c->conn);
+            c->io_flags &= ~CLIENT_IO_READ_DECOMPRESSED_CRON;
+        }
+    }
+}
+
 /* This is the IO thread timer interrupt, CONFIG_DEFAULT_HZ times per second.
  * The current responsibility is to detect clients that have been stuck in the
  * IO thread for too long and hand them over to the main thread for handling. */
@@ -842,6 +926,8 @@ int IOThreadCron(struct aeEventLoop *eventLoop, long long id, void *clientData) 
     UNUSED(eventLoop);
     UNUSED(id);
     IOThread *t = clientData;
+
+    run_with_period_io(t, server.compression_max_latency) IOThreadCompressionCron(t);
 
     /* Run cron tasks for the clients in the IO thread. */
     IOThreadClientsCron(t);
@@ -886,6 +972,8 @@ void initThreadedIO(void) {
         t->processing_clients = listCreate();
         t->pending_clients_to_main_thread = listCreate();
         t->clients = listCreate();
+        t->compression_clients = listCreate();
+        t->cronloops = 0;
         atomicSetWithSync(t->paused, IO_THREAD_UNPAUSED);
         atomicSetWithSync(t->running, 0);
 

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -341,7 +341,7 @@ void assignClientToIOThread(client *c) {
      * write, and then put it in the list, main thread will send these clients
      * to IO thread in beforeSleep. */
     connUnbindEventLoop(c->conn);
-    c->io_flags &= ~(CLIENT_IO_READ_ENABLED | CLIENT_IO_WRITE_ENABLED);
+    c->io_flags &= ~(CLIENT_IO_READ_ENABLED | CLIENT_IO_WRITE_ENABLED | CLIENT_IO_COMPRESSION_ENABLED);
 
     enqueuePendingClienstToIOThreads(c);
 }

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -892,11 +892,14 @@ void IOThreadCompressionCron(IOThread *t) {
         if (c->io_flags & CLIENT_IO_CLOSE_ASAP) continue;
         serverAssert(c->compression_state);
 
-        /* Usually writeCompressed will be called at the end of compressAndWrite
-         * but when compression maximum latency ms have passed we want to force
-         * flush to the compression buffer so we don't have much delays between
-         * writes to the socket */
-        if (c->flags & CLIENT_SLAVE) {
+        /* Usually compressAndWrite will be called at the end of
+         * consumeAndTryWriteCompressed but when compression maximum latency ms
+         * have passed we want to force flush to the compression buffer so we
+         * don't have much delays between writes to the socket */
+        if (clientHasPendingCompressionFlush(c)) {
+            /* Only master/replica clients support client compression for now. */
+            serverAssert(c->flags & CLIENT_SLAVE);
+
             int nwritten = compressAndWrite(c);
             if (nwritten < 0) {
                 if (connGetState(c->conn) != CONN_STATE_CONNECTED)
@@ -908,10 +911,9 @@ void IOThreadCompressionCron(IOThread *t) {
                 c->net_output_bytes += nwritten;
                 atomicIncr(server.stat_net_repl_output_bytes, nwritten);
             }
-        } else {
+        } else if (clientHasPendingCompressedData(c)) {
             /* Only master/replica clients support client compression for now. */
             serverAssert(c->flags & CLIENT_MASTER);
-
             c->io_flags |= CLIENT_IO_READ_DECOMPRESSED_CRON;
             readQueryFromClient(c->conn);
             c->io_flags &= ~CLIENT_IO_READ_DECOMPRESSED_CRON;

--- a/src/iothread.c
+++ b/src/iothread.c
@@ -886,6 +886,9 @@ void IOThreadCompressionCron(IOThread *t) {
     listIter li;
     listNode *ln;
     listRewind(t->compression_clients, &li);
+    /* TODO: if compression is generalized for all types of clients this cron
+     * will need to only process a portion of the clients (similar to
+     * IOThreadClientsCron) for performance reasons */
     while ((ln = listNext(&li))) {
         client *c = listNodeValue(ln);
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -2623,6 +2623,9 @@ static inline int _writeToClientSlaveIOThread(client *c, ssize_t *nwritten) {
         size_t last_written = 0;
         if (connCheckLastWritten(c->conn, &last_written)) {
             *nwritten += last_written;
+            /* Since nwritten stores the number of compressed bytes written to
+             * socket we also store the uncompressed size for stats. */
+            atomicIncr(server.stat_net_repl_uncompressed_bytes, consumed);
         } else {
             *nwritten += consumed;
         }
@@ -3828,6 +3831,11 @@ void readQueryFromClient(connection *conn) {
     size_t network_read;
     if (!connCheckLastRead(c->conn, &network_read)) {
         network_read = nread;
+    } else {
+        /* In case of compression nread is the number of decompressed bytes,
+         * whereas network_read stores the actual number of bytes read from
+         * socket. */
+        atomicIncr(server.stat_net_repl_decompressed_bytes, nread);
     }
 
     if (c->flags & CLIENT_MASTER) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -3706,7 +3706,7 @@ void readQueryFromClient(connection *conn) {
     size_t qblen, readlen;
 
     /* We have to read compressed data but compression for this client is
-     * currently disabled. This could happend f.e when client was just fetched
+     * currently disabled. This could happened f.e when client was just fetched
      * to main thread. */
     int pending_compression_read = c->compression_state &&
                                    !(c->io_flags & CLIENT_IO_COMPRESSION_ENABLED);

--- a/src/networking.c
+++ b/src/networking.c
@@ -2618,6 +2618,8 @@ static inline int _writeToClientSlaveIOThread(client *c, ssize_t *nwritten) {
         /* Note, that consumed is how much bytes we've read from the repl buffer,
          * where as the bytes we've written into the socket may be different if
          * connCheckLastWritten returns so (f.e compression case) */
+        /* TODO: if compression is generalized for all types of clients we will
+         * need to add this check in writeToClientNonSlave also */
         size_t last_written = 0;
         if (connCheckLastWritten(c->conn, &last_written)) {
             *nwritten += last_written;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2612,13 +2612,16 @@ static inline int _writeToClientSlaveIOThread(client *c, ssize_t *nwritten) {
     size_t pos = c->io_curr_repl_node == c->io_bound_repl_node ?
                  c->io_bound_block_pos : o->used;
     if (pos > c->io_curr_block_pos) {
-        int consumed = 0;
-        if (c->compression_state && c->io_flags & CLIENT_IO_COMPRESSION_ENABLED) {
-            consumed = consumeAndTryWriteCompressed(c, o->buf + c->io_curr_block_pos,
-                                                    pos-c->io_curr_block_pos, nwritten);
+        int consumed = connWrite(c->conn, o->buf+c->io_curr_block_pos,
+                                 pos-c->io_curr_block_pos);
+
+        /* Note, that consumed is how much bytes we've read from the repl buffer,
+         * where as the bytes we've written into the socket may be different if
+         * connCheckLastWritten returns so (f.e compression case) */
+        size_t last_written = 0;
+        if (connCheckLastWritten(c->conn, &last_written)) {
+            *nwritten += last_written;
         } else {
-            consumed = connWrite(c->conn, o->buf+c->io_curr_block_pos,
-                                pos-c->io_curr_block_pos);
             *nwritten += consumed;
         }
         if (consumed <= 0) return C_ERR;

--- a/src/networking.c
+++ b/src/networking.c
@@ -1863,7 +1863,7 @@ void unlinkClient(client *c) {
              * the main process is stale. SSL_shutdown() involves a handshake,
              * and it may block the caller when used with stale TLS state.*/
             if (c->flags & CLIENT_REPL_RDB_CHANNEL)
-                shutdown(c->conn->fd, SHUT_RDWR);
+                shutdown(connGetFd(c->conn), SHUT_RDWR);
             else
                 connShutdown(c->conn);
         }
@@ -2447,7 +2447,7 @@ static payloadHeader *processSentDataInEncodedBuffer(client *c, char *start_ptr,
  * and 'nwritten' is an output parameter, it means how many bytes server write
  * to client. */
 static int _writevToClient(client *c, ssize_t *nwritten) {
-    int iovmax = min(IOV_MAX, c->conn->iovcnt);
+    int iovmax = min(IOV_MAX, connGetIovcnt(c->conn));
     struct iovec iov[iovmax];
     ReplyIOV reply_iov = {iov, iovmax};
 
@@ -3793,40 +3793,19 @@ void readQueryFromClient(connection *conn) {
         /* Read as much as possible from the socket to save read(2) system calls. */
         readlen = sdsavail(c->querybuf);
     }
-
-    /* If we enabled client compression for replication make sure to decompress
-     * the data we've read before processing it.
-     * Note that the bytes read from socket will be <= decompressed data.
-     * Decompressed data will be written inside querybuf so in that case nread
-     * will still be the number of bytes written inside querybuf.
-     * network_read is how much we've read from socket and nread is the amount
-     * of decompressed data. For non-compression case these values are the same. */
-    int network_read = 0;
-    if (c->compression_state && c->flags & CLIENT_MASTER) {
-        nread = readFromSocketAndDecompress(c, c->querybuf + qblen, readlen,
-                                            &network_read);
-    } else {
-        nread = connRead(c->conn, c->querybuf+qblen, readlen);
-        network_read = nread;
-    }
-
-    if (nread <= 0) {
-        if (c->io_flags & CLIENT_IO_READ_DECOMPRESSED_CRON)
+    nread = connRead(c->conn, c->querybuf+qblen, readlen);
+    if (nread == -1) {
+        if (connGetState(conn) == CONN_STATE_CONNECTED) {
             goto done;
-
-        if (network_read == -1) {
-            if (connGetState(conn) == CONN_STATE_CONNECTED) {
-                goto done;
-            } else {
-                c->read_error = CLIENT_READ_CONN_DISCONNECTED;
-                freeClientAsync(c);
-                goto done;
-            }
-        } else if (network_read == 0) {
-            c->read_error = CLIENT_READ_CONN_CLOSED;
+        } else {
+            c->read_error = CLIENT_READ_CONN_DISCONNECTED;
             freeClientAsync(c);
             goto done;
         }
+    } else if (nread == 0) {
+        c->read_error = CLIENT_READ_CONN_CLOSED;
+        freeClientAsync(c);
+        goto done;
     }
 
     sdsIncrLen(c->querybuf,nread);
@@ -3840,6 +3819,11 @@ void readQueryFromClient(connection *conn) {
          * client's data. If this is a master running in IO thread the value of
          * c->lastinteraction will be updated during processClientsFromIOThread */
         c->io_lastinteraction = server.unixtime;
+
+    size_t network_read;
+    if (!connCheckLastRead(c->conn, &network_read)) {
+        network_read = nread;
+    }
 
     if (c->flags & CLIENT_MASTER) {
         if (c->running_tid == IOTHREAD_MAIN_THREAD_ID) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -3810,7 +3810,7 @@ void readQueryFromClient(connection *conn) {
         network_read = nread;
     }
 
-    if (network_read <= 0) {
+    if (nread <= 0) {
         if (c->io_flags & CLIENT_IO_READ_DECOMPRESSED_CRON)
             goto done;
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -226,6 +226,7 @@ client *createClient(connection *conn) {
     c->sockname = NULL;
     c->client_list_node = NULL;
     c->io_thread_client_list_node = NULL;
+    listInitNode(&c->io_thread_compression_clients_node, c);
     c->postponed_list_node = NULL;
     c->client_tracking_redirection = 0;
     c->client_tracking_prefixes = NULL;
@@ -251,6 +252,8 @@ client *createClient(connection *conn) {
     c->commands_processed = 0;
     c->task = NULL;
     c->node_id = NULL;
+    c->compression_level = 0;
+    c->compression_state = NULL;
     atomicSet(c->pending_read, 0);
     return c;
 }
@@ -2099,7 +2102,8 @@ void freeClient(client *c) {
 
     /* Log link disconnection with slave */
     if (clientTypeIsSlave(c)) {
-        const char *type = c->flags & CLIENT_REPL_RDB_CHANNEL ? " (rdbchannel)" : "";
+        int is_rdb_ch = c->flags & CLIENT_REPL_RDB_CHANNEL;
+        const char *type = is_rdb_ch ? " (rdbchannel)" : "";
         serverLog(LL_NOTICE,"Connection with replica%s %s lost.", type,
             replicationGetSlaveName(c));
     }
@@ -2109,6 +2113,9 @@ void freeClient(client *c) {
         resetReusableQueryBuf(c);
     sdsfree(c->querybuf);
     c->querybuf = NULL;
+
+    /* Disable compression if present */
+    clientDestroyCompressionState(c);
 
     /* Deallocate structures used to block on blocking ops. */
     /* If there is any in-flight command, we don't record their duration. */
@@ -2614,10 +2621,22 @@ static inline int _writeToClientSlave(client *c, ssize_t *nwritten) {
         size_t pos = c->io_curr_repl_node == c->io_bound_repl_node ?
                      c->io_bound_block_pos : o->used;
         if (pos > c->io_curr_block_pos) {
-            *nwritten = connWrite(c->conn, o->buf+c->io_curr_block_pos,
-                                  pos-c->io_curr_block_pos);
-            if (*nwritten <= 0) return C_ERR;
-            c->io_curr_block_pos += *nwritten;
+            int consumed = 0;
+            if (c->compression_state && c->io_flags & CLIENT_IO_COMPRESSION_ENABLED) {
+                consumed = consumeAndTryWriteCompressed(c, o->buf + c->io_curr_block_pos,
+                                                        pos-c->io_curr_block_pos, nwritten);
+            } else {
+                consumed = connWrite(c->conn, o->buf+c->io_curr_block_pos,
+                                    pos-c->io_curr_block_pos);
+                *nwritten += consumed;
+            }
+            if (consumed <= 0) return C_ERR;
+
+            /* Advance the block position with consumed, because that's how much
+             * bytes were read from the repl buffer node. *nwritten stores how
+             * much bytes were written to the socket, which for the compression
+             * case would most certainly be a different number. */
+            c->io_curr_block_pos += consumed;
         }
         /* If we fully sent the object and there are more nodes to send, go to the next one. */
         if (c->io_curr_block_pos == pos && c->io_curr_repl_node != c->io_bound_repl_node) {
@@ -2636,6 +2655,7 @@ static inline int _writeToClientSlave(client *c, ssize_t *nwritten) {
         if (*nwritten <= 0) return C_ERR;
         c->ref_block_pos += *nwritten;
     }
+
     /* If we fully sent the object on head, go to the next one. */
     listNode *next = listNextNode(c->ref_repl_buf_node);
     if (next && c->ref_block_pos == o->used) {
@@ -3685,13 +3705,23 @@ void readQueryFromClient(connection *conn) {
     int nread, big_arg = 0;
     size_t qblen, readlen;
 
-    if (!(c->io_flags & CLIENT_IO_READ_ENABLED)) {
+    /* We have to read compressed data but compression for this client is
+     * currently disabled. This could happend f.e when client was just fetched
+     * to main thread. */
+    int pending_compression_read = c->compression_state &&
+                                   !(c->io_flags & CLIENT_IO_COMPRESSION_ENABLED);
+
+    if (!(c->io_flags & CLIENT_IO_READ_ENABLED) || pending_compression_read) {
         atomicSetWithSync(c->pending_read, 1);
         return;
     } else if (server.io_threads_num > 1) {
         atomicSetWithSync(c->pending_read, 0);
     }
 
+    if (!(c->io_flags & CLIENT_IO_READ_ENABLED)) return;
+    if (pending_compression_read) {
+        return;
+    }
     c->read_error = 0;
 
     /* Update the number of reads of io threads on server */
@@ -3763,19 +3793,46 @@ void readQueryFromClient(connection *conn) {
         /* Read as much as possible from the socket to save read(2) system calls. */
         readlen = sdsavail(c->querybuf);
     }
-    nread = connRead(c->conn, c->querybuf+qblen, readlen);
-    if (nread == -1) {
-        if (connGetState(conn) == CONN_STATE_CONNECTED) {
-            goto done;
-        } else {
-            c->read_error = CLIENT_READ_CONN_DISCONNECTED;
+
+    /* If we enabled client compression for replication make sure to decompress
+     * the data we've read before processing it.
+     * Note that the bytes read from socket will be <= decompressed data.
+     * Decompressed data will be written inside querybuf so in that case nread
+     * will still be the number of bytes written inside querybuf.
+     * network_read is how much we've read from socket and nread is the amount
+     * of decompressed data. For non-compression case these values are the same. */
+    int network_read = 0;
+    if (c->compression_state && c->flags & CLIENT_MASTER) {
+        nread = readFromSocketAndDecompress(c, c->querybuf + qblen, readlen,
+                                            &network_read);
+
+        /* Ignore network_read when only reading decompressed data as we never
+         * read from socket.
+         * We only care if we actually had any decompressed data to read */
+        if (c->io_flags & CLIENT_IO_READ_DECOMPRESSED_CRON) {
+            if (nread <= 0) {
+                goto done;
+            }
+        }
+    } else {
+        nread = connRead(c->conn, c->querybuf+qblen, readlen);
+        network_read = nread;
+    }
+
+    if (nread <= 0) {
+        if (network_read == -1) {
+            if (connGetState(conn) == CONN_STATE_CONNECTED) {
+                goto done;
+            } else {
+                c->read_error = CLIENT_READ_CONN_DISCONNECTED;
+                freeClientAsync(c);
+                goto done;
+            }
+        } else if (network_read == 0) {
+            c->read_error = CLIENT_READ_CONN_CLOSED;
             freeClientAsync(c);
             goto done;
         }
-    } else if (nread == 0) {
-        c->read_error = CLIENT_READ_CONN_CLOSED;
-        freeClientAsync(c);
-        goto done;
     }
 
     sdsIncrLen(c->querybuf,nread);
@@ -3799,9 +3856,9 @@ void readQueryFromClient(connection *conn) {
         }
         atomicIncr(server.stat_net_repl_input_bytes, nread);
     } else {
-        atomicIncr(server.stat_net_input_bytes, nread);
+        atomicIncr(server.stat_net_input_bytes, network_read);
     }
-    c->net_input_bytes += nread;
+    c->net_input_bytes += network_read;
 
     if (!(c->flags & CLIENT_MASTER) &&
         /* The commands cached in the MULTI/EXEC queue have not been executed yet,

--- a/src/networking.c
+++ b/src/networking.c
@@ -2606,6 +2606,37 @@ static inline int _writeToClientNonSlave(client *c, ssize_t *nwritten) {
     return C_OK;
 }
 
+static inline int _writeToClientSlaveIOThread(client *c, ssize_t *nwritten) {
+    replBufBlock *o = listNodeValue(c->io_curr_repl_node);
+    /* The IO thread must not send data beyond the bound position. */
+    size_t pos = c->io_curr_repl_node == c->io_bound_repl_node ?
+                 c->io_bound_block_pos : o->used;
+    if (pos > c->io_curr_block_pos) {
+        int consumed = 0;
+        if (c->compression_state && c->io_flags & CLIENT_IO_COMPRESSION_ENABLED) {
+            consumed = consumeAndTryWriteCompressed(c, o->buf + c->io_curr_block_pos,
+                                                    pos-c->io_curr_block_pos, nwritten);
+        } else {
+            consumed = connWrite(c->conn, o->buf+c->io_curr_block_pos,
+                                pos-c->io_curr_block_pos);
+            *nwritten += consumed;
+        }
+        if (consumed <= 0) return C_ERR;
+
+        /* Advance the block position with consumed, because that's how much
+         * bytes were read from the repl buffer node. *nwritten stores how
+         * much bytes were written to the socket, which for the compression
+         * case would most certainly be a different number. */
+        c->io_curr_block_pos += consumed;
+    }
+    /* If we fully sent the object and there are more nodes to send, go to the next one. */
+    if (c->io_curr_block_pos == pos && c->io_curr_repl_node != c->io_bound_repl_node) {
+        c->io_curr_repl_node = listNextNode(c->io_curr_repl_node);
+        c->io_curr_block_pos = 0;
+    }
+    return C_OK;
+}
+
 /* This function does actual writing output buffers for slave client types,
  * it is called by writeToClient.
  * If we write successfully, it returns C_OK, otherwise, C_ERR is returned,
@@ -2616,34 +2647,7 @@ static inline int _writeToClientSlave(client *c, ssize_t *nwritten) {
     serverAssert(c->bufpos == 0 && listLength(c->reply) == 0);
 
     if (c->running_tid != IOTHREAD_MAIN_THREAD_ID) {
-        replBufBlock *o = listNodeValue(c->io_curr_repl_node);
-        /* The IO thread must not send data beyond the bound position. */
-        size_t pos = c->io_curr_repl_node == c->io_bound_repl_node ?
-                     c->io_bound_block_pos : o->used;
-        if (pos > c->io_curr_block_pos) {
-            int consumed = 0;
-            if (c->compression_state && c->io_flags & CLIENT_IO_COMPRESSION_ENABLED) {
-                consumed = consumeAndTryWriteCompressed(c, o->buf + c->io_curr_block_pos,
-                                                        pos-c->io_curr_block_pos, nwritten);
-            } else {
-                consumed = connWrite(c->conn, o->buf+c->io_curr_block_pos,
-                                    pos-c->io_curr_block_pos);
-                *nwritten += consumed;
-            }
-            if (consumed <= 0) return C_ERR;
-
-            /* Advance the block position with consumed, because that's how much
-             * bytes were read from the repl buffer node. *nwritten stores how
-             * much bytes were written to the socket, which for the compression
-             * case would most certainly be a different number. */
-            c->io_curr_block_pos += consumed;
-        }
-        /* If we fully sent the object and there are more nodes to send, go to the next one. */
-        if (c->io_curr_block_pos == pos && c->io_curr_repl_node != c->io_bound_repl_node) {
-            c->io_curr_repl_node = listNextNode(c->io_curr_repl_node);
-            c->io_curr_block_pos = 0;
-        }
-        return C_OK;
+        return _writeToClientSlaveIOThread(c, nwritten);
     }
 
     replBufBlock *o = listNodeValue(c->ref_repl_buf_node);
@@ -3718,10 +3722,6 @@ void readQueryFromClient(connection *conn) {
         atomicSetWithSync(c->pending_read, 0);
     }
 
-    if (!(c->io_flags & CLIENT_IO_READ_ENABLED)) return;
-    if (pending_compression_read) {
-        return;
-    }
     c->read_error = 0;
 
     /* Update the number of reads of io threads on server */
@@ -3805,21 +3805,15 @@ void readQueryFromClient(connection *conn) {
     if (c->compression_state && c->flags & CLIENT_MASTER) {
         nread = readFromSocketAndDecompress(c, c->querybuf + qblen, readlen,
                                             &network_read);
-
-        /* Ignore network_read when only reading decompressed data as we never
-         * read from socket.
-         * We only care if we actually had any decompressed data to read */
-        if (c->io_flags & CLIENT_IO_READ_DECOMPRESSED_CRON) {
-            if (nread <= 0) {
-                goto done;
-            }
-        }
     } else {
         nread = connRead(c->conn, c->querybuf+qblen, readlen);
         network_read = nread;
     }
 
-    if (nread <= 0) {
+    if (network_read <= 0) {
+        if (c->io_flags & CLIENT_IO_READ_DECOMPRESSED_CRON)
+            goto done;
+
         if (network_read == -1) {
             if (connGetState(conn) == CONN_STATE_CONNECTED) {
                 goto done;
@@ -3854,7 +3848,7 @@ void readQueryFromClient(connection *conn) {
             /* Same comment as for c->io_lastinteraction */
             c->io_read_reploff += nread;
         }
-        atomicIncr(server.stat_net_repl_input_bytes, nread);
+        atomicIncr(server.stat_net_repl_input_bytes, network_read);
     } else {
         atomicIncr(server.stat_net_input_bytes, network_read);
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -2085,6 +2085,9 @@ void freeClient(client *c) {
         listDelNode(server.clients_to_close,ln);
     }
 
+    /* Disable compression if present */
+    clientDestroyCompressionState(c);
+
     /* If it is our master that's being disconnected we should make sure
      * to cache the state to try a partial resynchronization later.
      *
@@ -2113,9 +2116,6 @@ void freeClient(client *c) {
         resetReusableQueryBuf(c);
     sdsfree(c->querybuf);
     c->querybuf = NULL;
-
-    /* Disable compression if present */
-    clientDestroyCompressionState(c);
 
     /* Deallocate structures used to block on blocking ops. */
     /* If there is any in-flight command, we don't record their duration. */

--- a/src/replication.c
+++ b/src/replication.c
@@ -4149,6 +4149,8 @@ int replDataBufStreamToDb(replDataBuf *buf, replDataBufToDbCtx *ctx) {
                 sdsIncrLen(c->querybuf, decompressed);
                 c->read_reploff += (long long) decompressed;
                 c->io_read_reploff += (long long int) decompressed;
+
+                atomicIncr(server.stat_net_repl_decompressed_bytes, decompressed);
             } else {
                 size_t bytes = min(PROTO_IOBUF_LEN, o->used - processed);
                 c->querybuf = sdscatlen(c->querybuf, &o->buf[processed], bytes);

--- a/src/replication.c
+++ b/src/replication.c
@@ -147,7 +147,7 @@ void putReplicasInPendingClientsToIOThreads(void) {
         if (replica->flags & CLIENT_PENDING_WRITE ||
             clientHasPendingReplies(replica) ||
             replicaFromIOThreadHasPendingRead(replica) ||
-            (replica->compression_state && mstime() - replica->lastinteraction > server.compression_max_latency))
+            clientHasPendingCompressionFlush(replica))
         {
             enqueuePendingClienstToIOThreads(replica);
         }

--- a/src/replication.c
+++ b/src/replication.c
@@ -146,7 +146,8 @@ void putReplicasInPendingClientsToIOThreads(void) {
          * also send them to the IO thread. */
         if (replica->flags & CLIENT_PENDING_WRITE ||
             clientHasPendingReplies(replica) ||
-            replicaFromIOThreadHasPendingRead(replica))
+            replicaFromIOThreadHasPendingRead(replica) ||
+            (replica->compression_state && mstime() - replica->lastinteraction > server.compression_max_latency))
         {
             enqueuePendingClienstToIOThreads(replica);
         }
@@ -1439,6 +1440,27 @@ void replconfCommand(client *c) {
                      server.repl_diskless_sync) {
                 c->slave_capa |= SLAVE_CAPA_RDB_CHANNEL_REPL;
             }
+        } else if (!strcasecmp(c->argv[j]->ptr, "compression")) {
+            long level;
+
+            if ((getLongFromObjectOrReply(c,c->argv[j+1], &level,NULL) != C_OK))
+                return;
+
+            if (server.io_threads_num > 1) {
+                serverLog(LL_NOTICE, "Client #%llu request for replication "
+                          "compression with level %ld accepted",
+                          (unsigned long long)c->id, level);
+
+                c->compression_level = level;
+            } else {
+                serverLog(LL_NOTICE, "Client #%llu request for replication "
+                          "compression rejected. Replication compression is only "
+                          "enabled with IO threads.",
+                          (unsigned long long)c->id);
+                c->compression_level = 0;
+                addReplyError(c, "Master has not enabled replication compression");
+                return;
+            }
         } else if (!strcasecmp(c->argv[j]->ptr,"ack")) {
             /* REPLCONF ACK is used by slave to inform the master the amount
              * of replication stream that it processed so far. It is an
@@ -1475,6 +1497,7 @@ void replconfCommand(client *c) {
              * that 'ack' might be received before we detect bgsave is done. */
             if (c->replstate == SLAVE_STATE_SEND_BULK_AND_STREAM)
                 replicaPutOnline(c);
+
             /* Note: this command does not reply anything! */
             return;
         } else if (!strcasecmp(c->argv[j]->ptr,"getack")) {
@@ -2636,6 +2659,12 @@ void readSyncBulkPayload(connection *conn) {
     if (server.repl_backlog == NULL) createReplicationBacklog();
     serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Finished with success");
 
+    /* If we agreed on compression with the master then setup compression on the
+     * master client. At this point we're done reading all non compressed payload
+     * from the master */
+    if (server.repl_master_compression_level)
+        clientEnableCompression(server.master, DECOMPRESS);
+
     if (server.supervised_mode == SUPERVISED_SYSTEMD) {
         redisCommunicateSystemd("STATUS=MASTER <-> REPLICA sync: Finished with success. Ready to accept connections in read-write mode.\n");
     }
@@ -3113,6 +3142,13 @@ void syncWithMaster(connection *conn) {
         if (useDisklessLoad()) {
             replconf_rdb_no_compress = 1;
             err = sendCommand(conn, "REPLCONF", "rdb-no-compress", "1", NULL);
+        }
+
+        /* Try to setup client compression if we're configured so */
+        if (server.repl_compression > 0) {
+            sds level = sdsfromlonglong(server.repl_compression);
+            err = sendCommand(conn, "REPLCONF", "compression", level, NULL);
+            sdsfree(level);
             if (err) goto write_error;
         }
 
@@ -3184,7 +3220,7 @@ void syncWithMaster(connection *conn) {
     }
 
     if (server.repl_state == REPL_STATE_RECEIVE_COMP_REPLY && !replconf_rdb_no_compress)
-        server.repl_state = REPL_STATE_RECEIVE_CAPA_REPLY;
+        server.repl_state = REPL_STATE_RECEIVE_CLIENT_COMP;
 
     /* Receive REPLCONF rdb-no-compress reply. */
     if (server.repl_state == REPL_STATE_RECEIVE_COMP_REPLY) {
@@ -3197,6 +3233,32 @@ void syncWithMaster(connection *conn) {
                                 "REPLCONF rdb-no-compress: %s", err);
         }
         sdsfree(err);
+        server.repl_state = REPL_STATE_RECEIVE_CLIENT_COMP;
+        return;
+    }
+
+    if (server.repl_state == REPL_STATE_RECEIVE_CLIENT_COMP && server.repl_compression <= 0)
+      server.repl_state = REPL_STATE_RECEIVE_CAPA_REPLY;
+
+    if (server.repl_state == REPL_STATE_RECEIVE_CLIENT_COMP) {
+        err = receiveSynchronousResponse(conn);
+        if (err == NULL) goto no_response_error;
+
+        /* Ignore the error if any, not all the Redis versions support
+         * REPLCONF compression. */
+        if (err[0] == '-') {
+            serverLog(LL_NOTICE,
+                      "(Non critical) Replication compression not enabled: %s",
+                      err);
+            server.repl_compression = 0;
+            server.repl_master_compression_level = 0;
+        } else {
+            serverLog(LL_NOTICE, "Master agreed to compression level %d",
+                      server.repl_compression);
+            server.repl_master_compression_level = server.repl_compression;
+        }
+        sdsfree(err);
+        err = NULL;
         server.repl_state = REPL_STATE_RECEIVE_CAPA_REPLY;
         return;
     }
@@ -3268,6 +3330,9 @@ void syncWithMaster(connection *conn) {
 
     if (psync_result == PSYNC_CONTINUE) {
         serverLog(LL_NOTICE, "MASTER <-> REPLICA sync: Master accepted a Partial Resynchronization.");
+        if (server.repl_master_compression_level > 0) {
+            clientEnableCompression(server.master, DECOMPRESS);
+        }
         if (server.supervised_mode == SUPERVISED_SYSTEMD) {
             redisCommunicateSystemd("STATUS=MASTER <-> REPLICA sync: Partial Resynchronization accepted. Ready to accept connections in read-write mode.\n");
         }
@@ -4056,6 +4121,9 @@ int replDataBufStreamToDb(replDataBuf *buf, replDataBufToDbCtx *ctx) {
     int ret = C_OK;
     client *c = ctx->client;
 
+    if (server.repl_master_compression_level > 0)
+        serverAssert(server.master->compression_state);
+
     blockingOperationStarts();
     while ((n = listFirst(buf->blocks))) {
         replDataBufBlock *o = listNodeValue(n);
@@ -4064,30 +4132,51 @@ int replDataBufStreamToDb(replDataBuf *buf, replDataBufToDbCtx *ctx) {
 
         size_t processed = 0;
         while (processed < o->used) {
-            size_t bytes = min(PROTO_IOBUF_LEN, o->used - processed);
-            c->querybuf = sdscatlen(c->querybuf, &o->buf[processed], bytes);
-            c->read_reploff += (long long int) bytes;
+            /* Consumed bytes from the current block in the current iteration. */
+            size_t consumed = 0;
+
+            if (server.repl_master_compression_level > 0) {
+                c->querybuf = sdsMakeRoomFor(c->querybuf, PROTO_IOBUF_LEN);
+
+                size_t qblen = sdslen(c->querybuf);
+                size_t avail = sdsavail(c->querybuf);
+                int decompressed = readFromBufAndDecompress(c, o->buf + processed,
+                                                            o->used - processed,
+                                                            c->querybuf + qblen,
+                                                            avail,
+                                                            &consumed);
+                serverAssert(decompressed >= 0);
+                sdsIncrLen(c->querybuf, decompressed);
+                c->read_reploff += (long long) decompressed;
+                c->io_read_reploff += (long long int) decompressed;
+            } else {
+                size_t bytes = min(PROTO_IOBUF_LEN, o->used - processed);
+                c->querybuf = sdscatlen(c->querybuf, &o->buf[processed], bytes);
+                c->read_reploff += (long long int) bytes;
+                c->io_read_reploff += (long long int) bytes;
+                consumed = bytes;
+            }
             c->lastinteraction = server.unixtime;
 
             /* We don't expect error return value but just in case. */
             ret = processInputBuffer(c);
             if (ret != C_OK) break;
 
-            processed += bytes;
-            buf->used -= bytes;
+            processed += consumed;
+            buf->used -= consumed;
 
             if (server.repl_debug_pause & REPL_DEBUG_ON_STREAMING_REPL_BUF)
                 debugPauseProcess();
 
             /* Check if we should yield back to the event loop */
             if (server.loading_process_events_interval_bytes &&
-                ((ctx->applied_offset + bytes) / server.loading_process_events_interval_bytes >
+                ((ctx->applied_offset + consumed) / server.loading_process_events_interval_bytes >
                   ctx->applied_offset / server.loading_process_events_interval_bytes))
             {
                 ctx->yield_callback(ctx);
                 processEventsWhileBlocked();
             }
-            ctx->applied_offset += bytes;
+            ctx->applied_offset += consumed;
 
             /* Check if we should continue processing */
             if (!ctx->should_continue(ctx)) {
@@ -4173,7 +4262,6 @@ static void rdbChannelStreamReplDataToDb(void) {
     };
 
     ret = replDataBufStreamToDb(&server.repl_full_sync_buffer, &ctx);
-
 out:
     /* If main channel state is CLOSE_ASAP, it means main channel faced a
      * problem while RDB is being loaded or while we are applying the
@@ -4467,6 +4555,11 @@ void replicationCacheMaster(client *c) {
     c->bufpos = 0;
     resetClient(c, -1);
     resetClientQbufState(c);
+
+    /* Make sure to destroy cached master's compression state as otherwise after
+     * resurrection its state would be invalid. The compression would be
+     * reinitialized next time we try to sync with the cached master. */
+    clientDestroyCompressionState(server.master);
 
     /* Save the master. Server.master will be set to null later by
      * replicationHandleMasterDisconnection(). */

--- a/src/replication.c
+++ b/src/replication.c
@@ -4556,11 +4556,6 @@ void replicationCacheMaster(client *c) {
     resetClient(c, -1);
     resetClientQbufState(c);
 
-    /* Make sure to destroy cached master's compression state as otherwise after
-     * resurrection its state would be invalid. The compression would be
-     * reinitialized next time we try to sync with the cached master. */
-    clientDestroyCompressionState(server.master);
-
     /* Save the master. Server.master will be set to null later by
      * replicationHandleMasterDisconnection(). */
     server.cached_master = server.master;

--- a/src/replication.c
+++ b/src/replication.c
@@ -3238,7 +3238,7 @@ void syncWithMaster(connection *conn) {
     }
 
     if (server.repl_state == REPL_STATE_RECEIVE_CLIENT_COMP && server.repl_compression <= 0)
-      server.repl_state = REPL_STATE_RECEIVE_CAPA_REPLY;
+        server.repl_state = REPL_STATE_RECEIVE_CAPA_REPLY;
 
     if (server.repl_state == REPL_STATE_RECEIVE_CLIENT_COMP) {
         err = receiveSynchronousResponse(conn);

--- a/src/server.c
+++ b/src/server.c
@@ -2821,6 +2821,8 @@ void resetServerStats(void) {
     atomicSet(server.stat_net_output_bytes, 0);
     atomicSet(server.stat_net_repl_input_bytes, 0);
     atomicSet(server.stat_net_repl_output_bytes, 0);
+    atomicSet(server.stat_net_repl_uncompressed_bytes, 0);
+    atomicSet(server.stat_net_repl_decompressed_bytes, 0);
     server.stat_unexpected_error_replies = 0;
     server.stat_total_error_replies = 0;
     server.stat_dump_payload_sanitizations = 0;
@@ -6381,6 +6383,7 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
     if (all_sections  || (dictFind(section_dict,"stats") != NULL)) {
         long long stat_net_input_bytes, stat_net_output_bytes;
         long long stat_net_repl_input_bytes, stat_net_repl_output_bytes;
+        long long stat_net_repl_uncompressed_bytes, stat_net_repl_decompressed_bytes;
         long long current_eviction_exceeded_time = server.stat_last_eviction_exceeded_time ?
             (long long) elapsedUs(server.stat_last_eviction_exceeded_time): 0;
         long long current_active_defrag_time = server.stat_last_active_defrag_time ?
@@ -6391,6 +6394,8 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         atomicGet(server.stat_net_repl_input_bytes, stat_net_repl_input_bytes);
         atomicGet(server.stat_net_repl_output_bytes, stat_net_repl_output_bytes);
         atomicGet(server.stat_client_qbuf_limit_disconnections, stat_client_qbuf_limit_disconnections);
+        atomicGet(server.stat_net_repl_uncompressed_bytes, stat_net_repl_uncompressed_bytes);
+        atomicGet(server.stat_net_repl_decompressed_bytes, stat_net_repl_decompressed_bytes);
 
         /* If we calculated the total reads and writes in the threads section,
          * we don't need to do it again, and also keep the values consistent. */
@@ -6472,6 +6477,12 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         info = genRedisInfoStringACLStats(info);
         if (!server.cluster_enabled && server.cluster_compatibility_sample_ratio) {
             info = sdscatprintf(info, "cluster_incompatible_ops:%lld\r\n", server.stat_cluster_incompatible_ops);
+        }
+        if (stat_net_repl_uncompressed_bytes > 0) {
+            info = sdscatprintf(info, "total_net_repl_uncompressed_bytes:%lld\r\n", stat_net_repl_uncompressed_bytes);
+        }
+        if (stat_net_repl_decompressed_bytes > 0) {
+            info = sdscatprintf(info, "total_net_repl_decompressed_bytes:%lld\r\n", stat_net_repl_decompressed_bytes);
         }
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2908,6 +2908,8 @@ void initServer(void) {
     server.memory_tracking_per_slot = clusterSlotStatsEnabled();
     resetReplicationBuffer();
 
+    server.repl_master_compression_level = 0;
+
     /* Make sure the locale is set on startup based on the config file. */
     if (setlocale(LC_COLLATE,server.locale_collate) == NULL) {
         serverLog(LL_WARNING, "Failed to configure LOCALE for invalid locale name.");

--- a/src/server.c
+++ b/src/server.c
@@ -2908,8 +2908,6 @@ void initServer(void) {
     server.memory_tracking_per_slot = clusterSlotStatsEnabled();
     resetReplicationBuffer();
 
-    server.repl_master_compression_level = 0;
-
     /* Make sure the locale is set on startup based on the config file. */
     if (setlocale(LC_COLLATE,server.locale_collate) == NULL) {
         serverLog(LL_WARNING, "Failed to configure LOCALE for invalid locale name.");

--- a/src/server.h
+++ b/src/server.h
@@ -2078,6 +2078,8 @@ struct redisServer {
     redisAtomic long long stat_net_output_bytes; /* Bytes written to network. */
     redisAtomic long long stat_net_repl_input_bytes; /* Bytes read during replication, added to stat_net_input_bytes in 'info'. */
     redisAtomic long long stat_net_repl_output_bytes; /* Bytes written during replication, added to stat_net_output_bytes in 'info'. */
+    redisAtomic long long stat_net_repl_uncompressed_bytes; /* Bytes read from repl buffer before being compressed and written during replication. */
+    redisAtomic long long stat_net_repl_decompressed_bytes; /* Decompressed bytes after reading compressed data during replication. */
     size_t stat_current_cow_peak;   /* Peak size of copy on write bytes. */
     size_t stat_current_cow_bytes;  /* Copy on write bytes while child is active. */
     monotime stat_current_cow_updated;  /* Last update time of stat_current_cow_bytes */

--- a/src/server.h
+++ b/src/server.h
@@ -66,6 +66,7 @@ typedef long long ustime_t; /* microsecond time type. */
 #include "connection.h" /* Connection abstraction */
 #include "eventnotifier.h" /* Event notification */
 #include "memory_prefetch.h"
+#include "client_comp.h"
 
 /* Forward declarations needed by redismodule.h and keymeta.h */
 struct redisObject;
@@ -455,6 +456,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 #define CLIENT_IO_REUSABLE_QUERYBUFFER (1ULL<<3) /* The client is using the reusable query buffer. */
 #define CLIENT_IO_CLOSE_ASAP (1ULL<<4) /* Close this client ASAP in IO thread. */
 #define CLIENT_IO_PENDING_CRON (1ULL<<5)  /* The client is pending cron job, to be processed in main thread. */
+#define CLIENT_IO_COMPRESSION_ENABLED (1ULL<<6)  /* The client compression is enabled for this client*/
+#define CLIENT_IO_READ_DECOMPRESSED_CRON (1ULL<<7)  /* The client is reading only decompressed data inside its querybuf */
 
 /* Definitions for client read errors. These error codes are used to indicate
  * various issues that can occur while reading or parsing data from a client. */
@@ -522,6 +525,7 @@ typedef enum {
     REPL_STATE_RECEIVE_IP_REPLY,    /* Wait for REPLCONF reply */
     REPL_STATE_RECEIVE_COMP_REPLY,  /* Wait for REPLCONF reply */
     REPL_STATE_RECEIVE_CAPA_REPLY,  /* Wait for REPLCONF reply */
+    REPL_STATE_RECEIVE_CLIENT_COMP, /* Wait for CLIENT_COMP reply */
     REPL_STATE_SEND_PSYNC,          /* Send PSYNC */
     REPL_STATE_RECEIVE_PSYNC_REPLY, /* Wait for PSYNC reply */
     /* --- End of handshake states --- */
@@ -787,10 +791,12 @@ typedef enum {
 #define NOTIFY_KEY_TRIMMED (1<<17)     /* module only key space notification, indicates a key trimmed during slot migration */
 #define NOTIFY_ALL (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_EXPIRED | NOTIFY_EVICTED | NOTIFY_STREAM | NOTIFY_MODULE) /* A flag */
 
+#define _run_with_period(_cronloops_, _ms_, _hz_) if (((_ms_) <= 1000/(_hz_)) || !((_cronloops_)%((_ms_)/(1000/(_hz_)))))
+
 /* Using the following macro you can run code inside serverCron() with the
  * specified period, specified in milliseconds.
  * The actual resolution depends on server.hz. */
-#define run_with_period(_ms_) if (((_ms_) <= 1000/server.hz) || !(server.cronloops%((_ms_)/(1000/server.hz))))
+#define run_with_period(_ms_) _run_with_period(server.cronloops, (_ms_), server.hz)
 
 /* We can print the stacktrace, so our assert is defined this way: */
 #define serverAssertWithInfo(_c,_o,_e) (likely(_e)?(void)0 : (_serverAssertWithInfo(_c,_o,#_e,__FILE__,__LINE__),redis_unreachable()))
@@ -1519,6 +1525,7 @@ typedef struct client {
     sds sockname;           /* Cached connection target address. */
     listNode *client_list_node; /* list node in client list */
     listNode *io_thread_client_list_node; /* list node in io thread client list */
+    listNode io_thread_compression_clients_node; /* list node in io thread compression clients list */
     listNode *postponed_list_node; /* list node within the postponed list */
     void *module_blocked_client; /* Pointer to the RedisModuleBlockedClient associated with this
                                   * client. This is set in case of module authentication before the
@@ -1535,7 +1542,10 @@ typedef struct client {
     void *auth_module;      /* The module that owns the callback, which is used
                              * to disconnect the client if the module is
                              * unloaded for cleanup. Opaque for Redis Core.*/
-
+    compressionState *compression_state; /* Opauqe handle to compression state */
+    int compression_level;  /* Compression level (0 means no compresison).
+                             * Currently not relevant for non-replication
+                             * connections. */
     /* If this client is in tracking mode and this field is non zero,
      * invalidation messages for keys fetched by this client will be sent to
      * the specified client ID. */
@@ -1610,6 +1620,8 @@ typedef struct __attribute__((aligned(CACHE_LINE_SIZE))) {
     pthread_mutex_t pending_clients_mutex;      /* Mutex for pending write list */
     list *pending_clients_to_main_thread;       /* Clients that are waiting to be executed by the main thread. */
     list *clients;                              /* IO thread managed clients. */
+    list *compression_clients;                  /* Clients that write/read compressed data */
+    size_t cronloops;
 } IOThread;
 
 /* Context for streaming replDataBuf to database */
@@ -2325,6 +2337,8 @@ struct redisServer {
     char master_replid[CONFIG_RUN_ID_SIZE+1];  /* Master PSYNC runid. */
     long long master_initial_offset;           /* Master PSYNC offset. */
     int repl_slave_lazy_flush;          /* Lazy FLUSHALL before loading DB? */
+    int repl_compression;               /* Should slave attempt compressed replication link */
+    int repl_master_compression_level;  /* Compression level agreed with master */
     /* Synchronous replication. */
     list *clients_waiting_acks;         /* Clients waiting in WAIT or WAITAOF. */
     int get_ack_from_slaves;            /* If true we send REPLCONF GETACK. */
@@ -2345,6 +2359,7 @@ struct redisServer {
     int oom_score_adj_values[CONFIG_OOM_COUNT];   /* Linux oom_score_adj configuration */
     int oom_score_adj;                            /* If true, oom_score_adj is managed */
     int disable_thp;                              /* If true, disable THP by syscall */
+    int compression_max_latency;                  /* flush interval for client compression in ms */
     /* Blocked clients */
     unsigned int blocked_clients;   /* # of clients executing a blocking cmd.*/
     unsigned int blocked_clients_by_type[BLOCKED_NUM];

--- a/src/socket.c
+++ b/src/socket.c
@@ -424,6 +424,7 @@ static ConnectionType CT_Socket = {
     .sync_read = connSocketSyncRead,
     .sync_readline = connSocketSyncReadLine,
     .get_last_read = NULL,
+    .get_last_written = NULL,
 
     /* pending data */
     .has_pending_data = NULL,

--- a/src/socket.c
+++ b/src/socket.c
@@ -423,6 +423,7 @@ static ConnectionType CT_Socket = {
     .sync_write = connSocketSyncWrite,
     .sync_read = connSocketSyncRead,
     .sync_readline = connSocketSyncReadLine,
+    .get_last_read = NULL,
 
     /* pending data */
     .has_pending_data = NULL,
@@ -430,36 +431,43 @@ static ConnectionType CT_Socket = {
 };
 
 int connBlock(connection *conn) {
-    if (conn->fd == -1) return C_ERR;
-    return anetBlock(NULL, conn->fd);
+    int fd = connGetFd(conn);
+    if (fd == -1) return C_ERR;
+    return anetBlock(NULL, fd);
 }
 
 int connNonBlock(connection *conn) {
-    if (conn->fd == -1) return C_ERR;
-    return anetNonBlock(NULL, conn->fd);
+    int fd = connGetFd(conn);
+    if (fd == -1) return C_ERR;
+    return anetNonBlock(NULL, fd);
 }
 
 int connEnableTcpNoDelay(connection *conn) {
-    if (conn->fd == -1) return C_ERR;
-    return anetEnableTcpNoDelay(NULL, conn->fd);
+    int fd = connGetFd(conn);
+    if (fd == -1) return C_ERR;
+    return anetEnableTcpNoDelay(NULL, fd);
 }
 
 int connDisableTcpNoDelay(connection *conn) {
-    if (conn->fd == -1) return C_ERR;
-    return anetDisableTcpNoDelay(NULL, conn->fd);
+    int fd = connGetFd(conn);
+    if (fd == -1) return C_ERR;
+    return anetDisableTcpNoDelay(NULL, fd);
 }
 
 int connKeepAlive(connection *conn, int interval) {
-    if (conn->fd == -1) return C_ERR;
-    return anetKeepAlive(NULL, conn->fd, interval);
+    int fd = connGetFd(conn);
+    if (fd == -1) return C_ERR;
+    return anetKeepAlive(NULL, fd, interval);
 }
 
 int connSendTimeout(connection *conn, long long ms) {
-    return anetSendTimeout(NULL, conn->fd, ms);
+    int fd = connGetFd(conn);
+    return anetSendTimeout(NULL, fd, ms);
 }
 
 int connRecvTimeout(connection *conn, long long ms) {
-    return anetRecvTimeout(NULL, conn->fd, ms);
+    int fd = connGetFd(conn);
+    return anetRecvTimeout(NULL, fd, ms);
 }
 
 int RedisRegisterConnectionTypeSocket(void)

--- a/src/tls.c
+++ b/src/tls.c
@@ -1233,6 +1233,7 @@ static ConnectionType CT_TLS = {
     .sync_write = connTLSSyncWrite,
     .sync_read = connTLSSyncRead,
     .sync_readline = connTLSSyncReadLine,
+    .get_last_read = NULL,
 
     /* pending data */
     .has_pending_data = tlsHasPendingData,

--- a/src/tls.c
+++ b/src/tls.c
@@ -1234,6 +1234,7 @@ static ConnectionType CT_TLS = {
     .sync_read = connTLSSyncRead,
     .sync_readline = connTLSSyncReadLine,
     .get_last_read = NULL,
+    .get_last_written = NULL,
 
     /* pending data */
     .has_pending_data = tlsHasPendingData,

--- a/src/unix.c
+++ b/src/unix.c
@@ -207,6 +207,7 @@ static ConnectionType CT_Unix = {
     .sync_write = connUnixSyncWrite,
     .sync_read = connUnixSyncRead,
     .sync_readline = connUnixSyncReadLine,
+    .get_last_read = NULL,
 
     /* pending data */
     .has_pending_data = NULL,

--- a/src/unix.c
+++ b/src/unix.c
@@ -208,6 +208,7 @@ static ConnectionType CT_Unix = {
     .sync_read = connUnixSyncRead,
     .sync_readline = connUnixSyncReadLine,
     .get_last_read = NULL,
+    .get_last_written = NULL,
 
     /* pending data */
     .has_pending_data = NULL,

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -41,6 +41,7 @@ set ::run_matching {} ; # If non empty, only tests matching pattern are run.
 set ::stop_on_failure 0
 set ::loop 0
 set ::tsan 0
+set ::compression 0
 
 if {[catch {cd tmp}]} {
     puts "tmp directory not found."
@@ -313,6 +314,8 @@ proc parse_options {} {
             set ::force_resp3 1
         } elseif {$opt eq {--tsan}} {
             set ::tsan 1
+        } elseif {$opt eq {--compression}} {
+            set ::compression 1
         } elseif {$opt eq "--help"} {
             puts "--single <pattern>      Only runs tests specified by pattern."
             puts "--dont-clean            Keep log files on exit."

--- a/tests/integration/psync2-master-restart.tcl
+++ b/tests/integration/psync2-master-restart.tcl
@@ -131,7 +131,6 @@ start_server {} {
             $offset == [status $replica master_repl_offset] &&
             $offset == [status $sub_replica master_repl_offset]
         } else {
-            show_cluster_status
             fail "Replicas and master offsets were unable to match *exactly*."
         }
 

--- a/tests/integration/psync2-master-restart.tcl
+++ b/tests/integration/psync2-master-restart.tcl
@@ -73,7 +73,7 @@ start_server {} {
     createComplexDataset $master 1000
 
     test "PSYNC2: Partial resync after Master restart using RDB aux fields with data" {
-        wait_for_condition 1000 100 {
+        wait_for_condition 500 100 {
             [status $master master_repl_offset] == [status $replica master_repl_offset] &&
             [status $master master_repl_offset] == [status $sub_replica master_repl_offset]
         } else {

--- a/tests/integration/psync2-master-restart.tcl
+++ b/tests/integration/psync2-master-restart.tcl
@@ -73,7 +73,7 @@ start_server {} {
     createComplexDataset $master 1000
 
     test "PSYNC2: Partial resync after Master restart using RDB aux fields with data" {
-        wait_for_condition 500 100 {
+        wait_for_condition 1000 100 {
             [status $master master_repl_offset] == [status $replica master_repl_offset] &&
             [status $master master_repl_offset] == [status $sub_replica master_repl_offset]
         } else {
@@ -90,7 +90,7 @@ start_server {} {
             restart_server 0 true false true now
             set master [srv 0 client]
         }
-        wait_for_condition 50 1000 {
+        wait_for_condition 100 1000 {
             [status $replica master_link_status] eq {up} &&
             [status $sub_replica master_link_status] eq {up}
         } else {
@@ -196,7 +196,7 @@ start_server {} {
 
         after 20
 
-        wait_for_condition 500 100 {
+        wait_for_condition 1000 100 {
             [status $master master_repl_offset] == [status $replica master_repl_offset] &&
             [status $master master_repl_offset] == [status $sub_replica master_repl_offset]
         } else {

--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -80,12 +80,10 @@ start_server {} {
 
         set compression_extra_mem 0
         if {$::compression} {
-            # each replica holds 2 temp user-space buffers of size 16Kb related
-            # to compression also zlib allocates about 268Kb for compressing and
-            # each replica client allocates its own zlib structure so we add
-            # that to the calculation
+            # each replica holds 2 temp user-space buffers of size 128Kb related
+            # to compression
             set numreplicas 3
-            set compression_extra_mem [expr {(2 * 16 + 268) * 1024 * $numreplicas}]
+            set compression_extra_mem [expr {(2 * 128) * 1024 * $numreplicas}]
         }
         set extra_mem [expr {[s used_memory] - $before_used - 1024*1024 - $compression_extra_mem}]
 
@@ -174,6 +172,15 @@ start_server {} {
         # Generating RDB will take 1000 seconds
         $master config set rdb-key-save-delay 1000000
         populate 1000 master 10000
+
+        # When compression is enabled the repl buffer may be consumed by the
+        # compression library faster than the data is actually send. We still
+        # trim the replication buffer in that case. In order for the following
+        # test to work we rely on replica2 being slow. If repl-rdb-channel is
+        # enabled though the repl buffer may be consumed faster than we expect.
+        if {$::compression} {
+            $replica2 config set repl-rdb-channel no
+        }
         $replica2 replicaof $master_host $master_port
         # Make sure replica2 is waiting bgsave
         wait_for_condition 5000 100 {
@@ -184,12 +191,13 @@ start_server {} {
         }
         # Replication actual backlog grow more than backlog setting since
         # the slow replica2 kept replication buffer.
-        if {$::compression} {
-            populate 2000 master 64000 0 false 0 true
-        } else {
-            populate 20000 master 10000
-        }
+        populate 20000 master 10000
         assert {[s repl_backlog_histlen] > [expr 10000*10000]}
+
+        # revert the config
+        if {$::compression} {
+            $replica2 config set repl-rdb-channel no
+        }
     }
 
     # Wait replica1 catch up with the master
@@ -240,10 +248,12 @@ start_server {} {
 
         # Since we trim replication backlog inrementally, replication backlog
         # memory may take time to be reclaimed.
-        wait_for_condition 1000 100 {
-            [s repl_backlog_histlen] < [expr 10000*10000]
-        } else {
-            fail "Replication backlog memory is not smaller"
+        if {!$::compression} {
+            wait_for_condition 1000 100 {
+                [s repl_backlog_histlen] < [expr 10000*10000]
+            } else {
+                fail "Replication backlog memory is not smaller"
+            }
         }
         resume_process $replica2_pid
     }

--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -76,7 +76,19 @@ start_server {} {
         # replication buffer, so all replicas output memory is not
         # more than double of replication buffer.
         set repl_buf_mem [s mem_total_replication_buffers]
-        set extra_mem [expr {[s used_memory]-$before_used-1024*1024}]
+        set repl_full_sync_buf_mem [s mem_replica_full_sync_buffer]
+
+        set compression_extra_mem 0
+        if {$::compression} {
+            # each replica holds 2 temp user-space buffers of size 16Kb related
+            # to compression also zlib allocates about 268Kb for compressing and
+            # each replica client allocates its own zlib structure so we add
+            # that to the calculation
+            set numreplicas 3
+            set compression_extra_mem [expr {(2 * 16 + 268) * 1024 * $numreplicas}]
+        }
+        set extra_mem [expr {[s used_memory] - $before_used - 1024*1024 - $compression_extra_mem}]
+
         if {$rdbchannel == "yes"} {
             # master's replication buffers should not grow
             assert {$extra_mem < 1024*1024}
@@ -172,7 +184,11 @@ start_server {} {
         }
         # Replication actual backlog grow more than backlog setting since
         # the slow replica2 kept replication buffer.
-        populate 20000 master 10000
+        if {$::compression} {
+            populate 2000 master 64000 0 false 0 true
+        } else {
+            populate 20000 master 10000
+        }
         assert {[s repl_backlog_histlen] > [expr 10000*10000]}
     }
 

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -299,8 +299,12 @@ start_server {tags {"repl external:skip debug_defrag:skip"}} {
             assert_lessthan [expr $peak_master_used_mem - $prev_used - $backlog_size] 1000000
             assert_lessthan $peak_master_rpl_buf [expr {$backlog_size + 1000000}]
             assert_lessthan $peak_master_slave_buf_size 1000000
-            # buffers in the replica are more than 5mb
-            assert_morethan $peak_replica_buf_size 5000000
+            # buffers in the replica are more than 5mb. Skip when testing
+            # compression as replica buf contains compressed data in that case
+            # which is a lot smaller
+            if {$::compression == 0} {
+                assert_morethan $peak_replica_buf_size 5000000
+            }
 
             stop_write_load $load_handle
         }
@@ -343,8 +347,14 @@ start_server {tags {"repl external:skip"}} {
                 fail "replica didn't start sync"
             }
 
-            # Create some traffic on replication stream
-            populate 100 master 100000
+            # Create some traffic on replication stream.
+            # In case of compression generate a command stream that is not well
+            # compressed so we can reach the buffer limits easier.
+            if {$::compression} {
+                populate 20 master 64000 0 false 0 true
+            } else {
+                populate 100 master 100000
+            }
 
             # Wait for replica's buffer limit reached
             wait_for_log_messages -1 {"*Replication buffer limit has been reached*"} 0 1000 10
@@ -361,7 +371,12 @@ start_server {tags {"repl external:skip"}} {
             }
 
             # Verify sync was not interrupted.
-            assert_equal [s 0 sync_full] [expr $prev_sync_full + 1]
+            # In the compression case the master's output buffer limits could be
+            # reached when replica stops accumulating command stream since we
+            # are sending a lot more data in this case.
+            if {$::compression == 0} {
+                assert_equal [s 0 sync_full] [expr $prev_sync_full + 1]
+            }
 
             # Verify db's are identical
             assert_morethan [$master dbsize] 0

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -449,7 +449,11 @@ start_server {tags {"repl external:skip debug_defrag:skip"}} {
             }
 
             # Generate replication traffic of ~20mb to disconnect the slave on obuf limit
-            populate 20 master 1000000 -1
+            if {$::compression} {
+                populate 200 master 1000000 -1 false 0 true
+            } else {
+                populate 20 master 1000000 -1
+            }
 
             wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 1000 10
             $replica config set key-load-delay 0

--- a/tests/integration/replication-rdbchannel.tcl
+++ b/tests/integration/replication-rdbchannel.tcl
@@ -351,13 +351,13 @@ start_server {tags {"repl external:skip"}} {
             # In case of compression generate a command stream that is not well
             # compressed so we can reach the buffer limits easier.
             if {$::compression} {
-                populate 20 master 64000 0 false 0 true
+                populate 1000 master 500000 0 false 0 true
             } else {
                 populate 100 master 100000
             }
 
             # Wait for replica's buffer limit reached
-            wait_for_log_messages -1 {"*Replication buffer limit has been reached*"} 0 1000 10
+            wait_for_log_messages -1 {"*Replication buffer limit has been reached*"} 0 100 10
 
             # Speed up loading
             $replica config set key-load-delay 0

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -108,13 +108,13 @@ start_server {tags {"repl external:skip"}} {
             $B config set loglevel debug
             r set test foo
             assert_equal [r getset test bar] foo
-            wait_for_condition 500 10 {
+            wait_for_condition 1000 10 {
                 [$A get test] eq "bar"
             } else {
                 fail "getset wasn't propagated"
             }
             assert_equal [r set test vaz get] bar
-            wait_for_condition 500 10 {
+            wait_for_condition 1000 10 {
                 [$A get test] eq "vaz"
             } else {
                 fail "set get wasn't propagated"
@@ -235,8 +235,8 @@ start_server {tags {"repl external:skip"}} {
             s role
         } {slave}
 
-        wait_for_sync r
         test {Sync should have transferred keys from master} {
+            wait_for_sync r
             r get mykey
         } {foo}
 
@@ -361,7 +361,7 @@ foreach mdl {no yes} rdbchannel {no yes} {
 
                             # Wait for all the three slaves to reach the "online"
                             # state from the POV of the master.
-                            set retry 500
+                            set retry 1000
                             while {$retry} {
                                 set info [r -3 info]
                                 if {[string match {*slave0:*state=online*slave1:*state=online*slave2:*state=online*} $info]} {
@@ -804,7 +804,7 @@ test {diskless loading short read} {
             for {set i 0} {$i < $attempts} {incr i} {
                 # wait for the replica to start reading the rdb
                 # using the log file since the replica only responds to INFO once in 2mb
-                set res [wait_for_log_messages -1 {"*Loading DB in memory*"} $loglines 2000 1]
+                set res [wait_for_log_messages -1 {"*Loading DB in memory*"} $loglines 10000 1]
                 set loglines [lindex $res 1]
 
                 # add some additional random sleep so that we kill the master on a different place each time
@@ -1496,7 +1496,7 @@ start_server {tags {"repl external:skip"}} {
 
 foreach disklessload {disabled on-empty-db} {
     test "Replica should reply LOADING while flushing a large db (disklessload: $disklessload)" {
-        start_server {} {
+        start_server {tags {"repl"}} {
             set replica [srv 0 client]
             start_server {} {
                 set master [srv 0 client]

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -82,30 +82,30 @@ proc kill_server config {
     }
 
     # check for leaks
-    # if {![dict exists $config "skipleaks"]} {
-    #     catch {
-    #         if {[string match {*Darwin*} [exec uname -a]]} {
-    #             tags {"leaks"} {
-    #                 test "Check for memory leaks (pid $pid)" {
-    #                     set output {0 leaks}
-    #                     catch {exec leaks $pid} output option
-    #                     # In a few tests we kill the server process, so leaks will not find it.
-    #                     # It'll exits with exit code >1 on error, so we ignore these.
-    #                     if {[dict exists $option -errorcode]} {
-    #                         set details [dict get $option -errorcode]
-    #                         if {[lindex $details 0] eq "CHILDSTATUS"} {
-    #                               set status [lindex $details 2]
-    #                               if {$status > 1} {
-    #                                   set output "0 leaks"
-    #                               }
-    #                         }
-    #                     }
-    #                     set output
-    #                 } {*0 leaks*}
-    #             }
-    #         }
-    #     }
-    # }
+    if {![dict exists $config "skipleaks"]} {
+        catch {
+            if {[string match {*Darwin*} [exec uname -a]]} {
+                tags {"leaks"} {
+                    test "Check for memory leaks (pid $pid)" {
+                        set output {0 leaks}
+                        catch {exec leaks $pid} output option
+                        # In a few tests we kill the server process, so leaks will not find it.
+                        # It'll exits with exit code >1 on error, so we ignore these.
+                        if {[dict exists $option -errorcode]} {
+                            set details [dict get $option -errorcode]
+                            if {[lindex $details 0] eq "CHILDSTATUS"} {
+                                  set status [lindex $details 2]
+                                  if {$status > 1} {
+                                      set output "0 leaks"
+                                  }
+                            }
+                        }
+                        set output
+                    } {*0 leaks*}
+                }
+            }
+        }
+    }
 
     # kill server and wait for the process to be totally exited
     send_data_packet $::test_server_fd server-killing $pid

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -82,30 +82,30 @@ proc kill_server config {
     }
 
     # check for leaks
-    if {![dict exists $config "skipleaks"]} {
-        catch {
-            if {[string match {*Darwin*} [exec uname -a]]} {
-                tags {"leaks"} {
-                    test "Check for memory leaks (pid $pid)" {
-                        set output {0 leaks}
-                        catch {exec leaks $pid} output option
-                        # In a few tests we kill the server process, so leaks will not find it.
-                        # It'll exits with exit code >1 on error, so we ignore these.
-                        if {[dict exists $option -errorcode]} {
-                            set details [dict get $option -errorcode]
-                            if {[lindex $details 0] eq "CHILDSTATUS"} {
-                                  set status [lindex $details 2]
-                                  if {$status > 1} {
-                                      set output "0 leaks"
-                                  }
-                            }
-                        }
-                        set output
-                    } {*0 leaks*}
-                }
-            }
-        }
-    }
+    # if {![dict exists $config "skipleaks"]} {
+    #     catch {
+    #         if {[string match {*Darwin*} [exec uname -a]]} {
+    #             tags {"leaks"} {
+    #                 test "Check for memory leaks (pid $pid)" {
+    #                     set output {0 leaks}
+    #                     catch {exec leaks $pid} output option
+    #                     # In a few tests we kill the server process, so leaks will not find it.
+    #                     # It'll exits with exit code >1 on error, so we ignore these.
+    #                     if {[dict exists $option -errorcode]} {
+    #                         set details [dict get $option -errorcode]
+    #                         if {[lindex $details 0] eq "CHILDSTATUS"} {
+    #                               set status [lindex $details 2]
+    #                               if {$status > 1} {
+    #                                   set output "0 leaks"
+    #                               }
+    #                         }
+    #                     }
+    #                     set output
+    #                 } {*0 leaks*}
+    #             }
+    #         }
+    #     }
+    # }
 
     # kill server and wait for the process to be totally exited
     send_data_packet $::test_server_fd server-killing $pid

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -126,6 +126,9 @@ proc assert_refcount_morethan {key ref} {
 # max retries and delay between retries. Otherwise the 'elsescript' is
 # executed.
 proc wait_for_condition {maxtries delay e _else_ elsescript} {
+    if {$::compression} {
+        set maxtries [expr $maxtries * 3]
+    }
     if {$_else_ ne "else"} {
         error "$_else_ must be equal to \"else\""
     }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -149,6 +149,9 @@ proc wait_replica_online {r {replica_id 0} {maxtries 50} {delay 100}} {
     if {$::tsan} {
         set maxtries [expr {$maxtries * 2}]
     }
+    if {$::compression} {
+        set maxtries [expr {$maxtries * 3}]
+    }
 
     wait_for_condition $maxtries $delay {
         [string match "*slave$replica_id:*,state=online*" [$r info replication]]
@@ -163,6 +166,9 @@ proc wait_for_ofs_sync {r1 r2} {
     # wait time here JIC
     if {$::tsan} {
         set maxtries 100
+    }
+    if {$::compression} {
+        set maxtries 150
     }
     wait_for_condition $maxtries 100 {
         [status $r1 master_repl_offset] eq [status $r2 master_repl_offset]
@@ -220,6 +226,9 @@ proc verify_log_message {srv_idx pattern from_line} {
 # wait for pattern to be found in server's stdout after certain line number
 # return value is a list containing the line that matched the pattern and the line number
 proc wait_for_log_messages {srv_idx patterns from_line maxtries delay} {
+    if {$::compression} {
+        set maxtries [expr {$maxtries * 3}]
+    }
     set retry $maxtries
     set next_line [expr $from_line + 1] ;# searching form the line after
     set stdout [srv $srv_idx stdout]

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -772,7 +772,7 @@ proc resume_process {pid} {
         after 100
     }
 
-    if {$attemp == $max_attempts} {
+    if {$attempt == $max_attempts} {
         fail "system failed to initiate resuming of process"
     }
 

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -772,11 +772,11 @@ proc resume_process {pid} {
         after 100
     }
 
-    if {$attempt == $max_attempts} {
-        fail "system failed to initiate resuming of process"
+    set max_attempts 50
+    if {$::compression} {
+        set max_attempts 150
     }
-
-    wait_for_condition 50 1000 {
+    wait_for_condition $max_attempts 1000 {
         [string match "R*" [exec ps -o state= -p $pid]] ||
         [string match "S*" [exec ps -o state= -p $pid]]
     } else {

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -772,6 +772,10 @@ proc resume_process {pid} {
         after 100
     }
 
+    if {$attemp == $max_attempts} {
+        fail "system failed to initiate resuming of process"
+    }
+
     wait_for_condition 50 1000 {
         [string match "R*" [exec ps -o state= -p $pid]] ||
         [string match "S*" [exec ps -o state= -p $pid]]

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -666,11 +666,15 @@ proc populate {num {prefix key:} {size 3} {idx 0} {prints false} {expires 0} {ra
     r $idx deferred 1
     if {$num > 16} {set pipeline 16} else {set pipeline $num}
     if {$random} {
-        set val [randstring $size $size]
+        set baseval [randstring $size $size]
     } else {
         set val [string repeat A $size]
     }
     for {set j 0} {$j < $pipeline} {incr j} {
+        if {$random} {
+            set jstr [format "%08d" $j]
+            set val [string replace $baseval 0 7 $jstr]
+        }
         if {$expires > 0} {
             r $idx set $prefix$j $val ex $expires
         } else {
@@ -679,6 +683,10 @@ proc populate {num {prefix key:} {size 3} {idx 0} {prints false} {expires 0} {ra
         if {$prints} {puts $j}
     }
     for {} {$j < $num} {incr j} {
+        if {$random} {
+            set jstr [format "%08d" $j]
+            set val [string replace $baseval 0 7 $jstr]
+        }
         if {$expires > 0} {
             r $idx set $prefix$j $val ex $expires
         } else {

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -129,7 +129,7 @@ proc waitForBgrewriteaof r {
 }
 
 proc wait_for_sync r {
-    set maxtries 50
+    set maxtries 200
     # tsan adds significant overhead to the execution time, so we increase the
     # wait time here JIC
     if {$::tsan} {
@@ -653,10 +653,14 @@ proc stop_bg_complex_data {handle} {
 # Write num keys with the given key prefix and value size (in bytes). If idx is
 # given, it's the index (AKA level) used with the srv procedure and it specifies
 # to which Redis instance to write the keys.
-proc populate {num {prefix key:} {size 3} {idx 0} {prints false} {expires 0}} {
+proc populate {num {prefix key:} {size 3} {idx 0} {prints false} {expires 0} {random false}} {
     r $idx deferred 1
     if {$num > 16} {set pipeline 16} else {set pipeline $num}
-    set val [string repeat A $size]
+    if {$random} {
+        set val [randstring $size $size]
+    } else {
+        set val [string repeat A $size]
+    }
     for {set j 0} {$j < $pipeline} {incr j} {
         if {$expires > 0} {
             r $idx set $prefix$j $val ex $expires

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -90,6 +90,7 @@ set ::large_memory 0
 set ::log_req_res 0
 set ::force_resp3 0
 set ::debug_defrag 0
+set ::compression 0
 
 # Set to 1 when we are running in client mode. The Redis test uses a
 # server-client model to run tests simultaneously. The server instance
@@ -722,6 +723,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set ::ignoredigest 1
     } elseif {$opt eq {--debug-defrag}} {
         set ::debug_defrag 1
+    } elseif {$opt eq {--compression}} {
+        set ::compression 1
     } elseif {$opt eq {--help}} {
         print_help_screen
         exit 0


### PR DESCRIPTION
# Quick overview

- Added new `compressionState` structure
- master/replica clients agree on repl compression level during sync (controlled by "repl-compression" config). Repl-stream compression allowed only if IO-threads are enabled on both master and replica.
- allocate and assign `compressionState` to master/replica clients after syncrhonization. For multi-replica case each replica would have its own `compressionState`.
- bypass `connWrite`/`connRead` in `writeToClientSlave`/`readQueryFromClient` for compression case by calling compression specific functions that internally call `connWrite`/`connRead` and then do compression/decompression.
- master sends compressed repl stream to replica. Opposite direction (replica->master) is not compressed as little traffic is expected there and compression would have caused additional compressionState allocations.
- For dual-channel RDB replication - main channel receives compressed data - `replDataBufStreamToDb` handles decompressing the data.
- reading compressed data (replica-side) may result in the following case - we read everything from socket. The compressed data is then partially decompressed filling up the whole client->querybuf available space. `readQueryFromClient` wouldn't be called again as there is nothing to read from socket - but we still have compressed data we can process. This is currently dealt with a  cron inside IO-thread.
-  Similar problem in the master-side - when writing to a replica the repl-stream is written inside zlib structures. Then we try to compress the data and send it to socket. `zlib` doesn't always spit out compressed data for efficiency-sake, thus during `writeToClientSlave` we may have read the replication buffer but not send any compressed data. In order not to slow down replication too much awe flush zlib's buffers in a set interval (config compression-max-latency) - this is again done via the IO-thread compression cron. 

# Problems
- bypassing connWrite/connRead is not pretty. 
- IOThreadCompressionCron is also ugly as it calls `readQueryFromClient`

# Solutions tried
- wrap the underlying connection with a new compressionConnection - seems awkard as the wrapping needs to happen after master/replica sync. Also was hard to make it work (f.e created syncronization issues like replica reading  compressed data via connRead or reading uncompressed data but thought was compressed).
- introduce `compression_read` and `compression_write` callbacks inside `connection` which are opaquely called inside `connRead` and `connWrite` - also hard to reason when to initialize these callbacks and when to destroy them, so again creates the need for workarounds elsewhere in code.